### PR TITLE
feat : 축제 상세페이지 지역 날씨정보 및 아이콘 구현

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 /** 2023/07/04 - Axios instance 생성 - by sineTlsl */
 export const instance = axios.create({
   baseURL: `${process.env.REACT_APP_API_URL}`,
-  timeout: 1000,
+  timeout: 5000,
   headers: {
     'Content-Type': 'application/json',
     'ngrok-skip-browser-warning': '69420',

--- a/src/api/detail.ts
+++ b/src/api/detail.ts
@@ -4,5 +4,7 @@ import { FestivalDetailType } from 'types/api/detail';
 
 /** 2023/07/11 - 축제 상세리스트 GET 요청 - by parksubeom */
 export const getDetailList = (contentId: string) => {
-  return instance.get<FestivalDetailType>(`/festivals/${contentId}`);
+  return instance.get<FestivalDetailType>(`/festivals/${contentId}`, {
+    headers: { 'No-Auth': 'True' },
+  });
 };

--- a/src/api/recommend.ts
+++ b/src/api/recommend.ts
@@ -7,6 +7,7 @@ import { RecommendListType, RecommendRequest } from 'types/api/recommend';
 export const getRecommendList = async (params: RecommendRequest) => {
   const { data } = await instance.get<RecommendListType[]>('/festivals/detailrecommend', {
     params,
+    headers: { 'No-Auth': 'True' },
   });
 
   return data;

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -6,6 +6,7 @@ import { WeatherRequest, WeatherType } from '../types/api/weather';
 export const getWeather = async (params: WeatherRequest) => {
   const { data } = await instance.get<WeatherType>('/api/weather', {
     params,
+    headers: { 'No-Auth': 'True' },
   });
 
   return data;

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -1,0 +1,12 @@
+import instance from './axiosInstance';
+
+// type
+import { WeatherRequest, WeatherType } from '../types/api/weather';
+
+export const getWeather = async (params: WeatherRequest) => {
+  const { data } = await instance.get<WeatherType>('/api/weather', {
+    params,
+  });
+
+  return data;
+};

--- a/src/components/RecommendFestival.tsx
+++ b/src/components/RecommendFestival.tsx
@@ -52,13 +52,12 @@ const RecommendFestival: React.FC<RecommendFestivalProps> = ({ fastivaldata }) =
       return newErrors;
     });
   };
-
   return (
     <>
       <Swiper {...swiperOptions} className="mySwiper">
         {fastivaldata.map((card, index) => (
           <SwiperSlide key={`card-${index + 1}`}>
-            <RecommendCard>
+            <RecommendCard href={card.festivalId.toString()}>
               <div className="card-image">
                 {imageErrors[index] ? (
                   <img src="/assets/images/ticat-cover-image.png" alt="fastival image" />
@@ -80,7 +79,7 @@ const RecommendFestival: React.FC<RecommendFestivalProps> = ({ fastivaldata }) =
 
 export default RecommendFestival;
 
-const RecommendCard = styled.div`
+const RecommendCard = styled.a`
   /* width: 180px;
   height: 200px; */
   color: var(--color-dark);

--- a/src/components/WeatherIcon.tsx
+++ b/src/components/WeatherIcon.tsx
@@ -1,0 +1,25 @@
+import { FaSun, FaCloud, FaSnowflake, FaCloudRain } from 'react-icons/fa';
+import { WeatherType } from 'types/api/weather';
+
+interface FestivalCoverProps {
+  regionWeather?: WeatherType;
+}
+/**사용법 :
+ * 1.해당 축제의 좌표를 받아와서 api/weather 에 있는 getWeather 함수를 이용하여 해당지역 날씨를 받아온다.
+ * 2.해당지역 날씨를 regionWeater라고 정의하고, 지역날씨정보를 WeatherIcon 컴포넌트의 프롭스로 내려준다.
+ * 3.프롭스로 내려받은 날씨정보에서 현재 기상정보를 뽑아서 WeaterIcon과 매핑하여 일치하는 아이콘을 리턴한다.
+ */
+export const WeatherIcon: React.FC<FestivalCoverProps> = ({ regionWeather }) => {
+  const weather: string = regionWeather ? regionWeather?.weather.sky : '맑음';
+  const WeatherIcons: { [key: string]: JSX.Element } = {
+    맑음: <FaSun />,
+    비: <FaCloudRain />,
+    소나기: <FaCloudRain />,
+    흐림: <FaCloud />,
+    구름많음: <FaCloud />,
+    눈: <FaSnowflake />,
+  };
+  const Icon: JSX.Element = WeatherIcons[weather] || <FaSun />;
+  return Icon;
+};
+export default WeatherIcon;

--- a/src/components/detail/FestivalCover.tsx
+++ b/src/components/detail/FestivalCover.tsx
@@ -32,7 +32,7 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
   /** 2023-07-20 - 현재 축제의 좋아요 요청/좋아요 취소 요청을 보내는 함수 - by parksubeom */
   const LikedHandler = () => {
     //https://ticat.store/festivals/2992167/favorite 로 엑세스토큰담아서 post요청 보내면된다
-    if (detailList.liked === true) {
+    if (festivalLiked === true) {
       festivalUnLikedRequest(detailList.festivalId);
       setFestivalLiked(!festivalLiked);
     } else {
@@ -99,7 +99,7 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
           ) : null}
           <button
             className="calendar-icon-btn"
-            onClick={() => handleCopyClipBoard(`${process.env.REACT_APP_DEV_BASEURL}${location.pathname}`)}>
+            onClick={() => handleCopyClipBoard(`${window.location.origin}${location.pathname}`)}>
             <FiShare2 />
           </button>
         </BtnSection>
@@ -198,8 +198,9 @@ const BtnSection = styled.div`
     }
   }
   > .calendar-icon-btn {
+    display: flex;
     cursor: pointer;
-    text-align: center;
+    align-items: center;
     justify-content: center;
     height: 3.5rem;
     width: 3.5rem;

--- a/src/components/detail/FestivalCover.tsx
+++ b/src/components/detail/FestivalCover.tsx
@@ -2,15 +2,18 @@ import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { festivalLikedRequest, festivalUnLikedRequest } from '@api/festivalliked';
+import { getWeather } from '@api/weather';
+import { WeatherRequest, WeatherType } from 'types/api/weather';
+import { WeatherIcon } from '@components/WeatherIcon';
 //icon
 import { TiLocation } from 'react-icons/ti';
-import { BiSun, BiSolidHeart } from 'react-icons/bi';
+import { BiSolidHeart } from 'react-icons/bi';
 import { FiHeart, FiShare2 } from 'react-icons/fi';
 import { LuTicket } from 'react-icons/lu';
 import { BsCalendarPlus } from 'react-icons/bs';
 import { FestivalDetailType } from 'types/api/detail';
 import { formatDate } from '@utils/formatDate';
-import { shareKakao } from '@utils/shareKakao';
+
 interface FestivalCoverProps {
   detailList: FestivalDetailType;
 }
@@ -18,6 +21,7 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
   const location = useLocation();
   const [defaultImg, setDefaultImg] = useState(detailList.image);
   const [festivalLiked, setFestivalLiked] = useState(detailList.liked);
+  const [regionWeather, setRegionWeather] = useState<WeatherType | undefined>();
   const eventhomepage = detailList.eventhomepage.slice(
     // 축제 홈페이지 주소가 옛날 데이터 주소는 url이 그대로오고, 요즘 데이터는 <a>태그가 붙어서 오기 때문에 분기가 필요하다
     detailList.eventhomepage.indexOf('http'),
@@ -58,13 +62,27 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
       window.location.assign(eventhomepage);
     }
   };
+
+  /**2023-07-22 - 해당 축제의 위치에 날씨를 불러오는 함수 - by parksubeom */
+  const fetchWeather = async () => {
+    const params: WeatherRequest = {
+      currentLongitude: detailList.mapx,
+      currentLatitude: detailList.mapy,
+    };
+    const res = await getWeather(params);
+    setRegionWeather(res);
+  };
+
+  useEffect(() => {
+    fetchWeather();
+  }, []);
   return (
     <CoverContainer>
       <img src={defaultImg} onError={ImgErrorHandler}></img>
       <div className="wather-info flex-all-center">
-        <span>축제날씨</span>
+        <span>{regionWeather ? regionWeather.region : 'Loding...'}</span>
         <span className="wather-icon flex-all-center">
-          <BiSun />
+          <WeatherIcon regionWeather={regionWeather} />
         </span>
       </div>
       <div className="festival-info">

--- a/src/components/detail/FestivalInfo.tsx
+++ b/src/components/detail/FestivalInfo.tsx
@@ -4,7 +4,6 @@ interface FestivalCoverProps {
   detailList: FestivalDetailType;
 }
 const FestivalInfo: React.FC<FestivalCoverProps> = ({ detailList }) => {
-  console.log(detailList);
   return (
     <>
       <InfoContainer>

--- a/src/components/detail/FestivalInfo.tsx
+++ b/src/components/detail/FestivalInfo.tsx
@@ -4,22 +4,23 @@ interface FestivalCoverProps {
   detailList: FestivalDetailType;
 }
 const FestivalInfo: React.FC<FestivalCoverProps> = ({ detailList }) => {
+  console.log(detailList);
   return (
     <>
       <InfoContainer>
         <h2>행사 소개</h2>
-        <p className="mobile-fontsize">{detailList.overview.replaceAll('<br>', ' ')}</p>
+        <p className="mobile-fontsize">{detailList.overview.replaceAll(/(<([^>]+)>)/gi, ' ')}</p>
         <FestivalContact>
           <p className="mobile-fontsize">행사 연락처</p>
           <span className="mobile-fontsize">{detailList.tel}</span>
         </FestivalContact>
         <FestivalContact>
           <p className="mobile-fontsize">행사위치</p>
-          <span className="mobile-fontsize">{detailList.eventplace.replaceAll('<br>', ' ')}</span>
+          <span className="mobile-fontsize">{detailList.eventplace.replaceAll(/(<([^>]+)>)/gi, ' ')}</span>
         </FestivalContact>
         <FestivalContact>
           <p className="mobile-fontsize">이용료</p>
-          <span className="mobile-fontsize">{detailList.price.replaceAll('<br>', ' ')}</span>
+          <span className="mobile-fontsize">{detailList.price.replaceAll(/(<([^>]+)>)/gi, ' ')}</span>
         </FestivalContact>
       </InfoContainer>
     </>

--- a/src/components/detail/Recommend.tsx
+++ b/src/components/detail/Recommend.tsx
@@ -16,13 +16,6 @@ interface FestivalCoverProps {
 }
 const Recommend: React.FC<FestivalCoverProps> = ({ detailList }) => {
   const [recommendlList, setRecommendList] = useState<RecommendListType[] | undefined>();
-  /** 2023.07.05 recommend banner swiper options - by mscojl24 */
-  const swiperOptions: RecommendSwiperOptions = {
-    spaceBetween: 110,
-    slidesPerView: 3,
-    grabCursor: true,
-    loop: true,
-  };
 
   /** 2023/07/12 - 축제 상세 데이터 요청 함수 - by parksubeom */
   const fetchRecommendlList = async () => {
@@ -32,17 +25,36 @@ const Recommend: React.FC<FestivalCoverProps> = ({ detailList }) => {
     const res = await getRecommendList(category);
     setRecommendList(res);
   };
-
   useEffect(() => {
     fetchRecommendlList();
   }, []);
+
   return (
-    <RecommendCardSection>{recommendlList && <RecommendFestival fastivaldata={recommendlList} />}</RecommendCardSection>
+    <LocationContainer>
+      <h2>추천 축제</h2>
+      <RecommendCardSection>
+        {recommendlList && <RecommendFestival fastivaldata={recommendlList} />}
+      </RecommendCardSection>
+    </LocationContainer>
   );
 };
 
 export default Recommend;
 
+const LocationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 2rem;
+
+  > h2 {
+    color: var(--color-dark);
+    font-size: 24px;
+    font-weight: bold;
+  }
+`;
+
 const RecommendCardSection = styled.div`
-  padding: 3rem 2rem;
+  padding: 3rem 0;
 `;

--- a/src/types/api/weather.ts
+++ b/src/types/api/weather.ts
@@ -1,0 +1,20 @@
+export interface WeatherType {
+  region: string;
+  weather: {
+    temp: number;
+    rainAmount: string;
+    humid: number;
+    lastUpdateTime: string;
+    sky: string;
+  };
+  message: string;
+}
+
+export interface WeatherRequest {
+  currentLongitude: number;
+  currentLatitude: number;
+}
+
+export interface WeatherResponse {
+  data?: WeatherType;
+}


### PR DESCRIPTION
### Branch
`fe-feat/DetailPage/#34` -> `dev`

### 변경사항
- 추천 축제 클릭 시 해당축제로 이동되도록 변경
- (진영님 피드백)축제 소개글 데이터 받아올 때 딸려오는 HTML 태그 제거 
- (시은님 피드백)엑시오스 인스턴스 타임아웃 1000 => 5000 으로 변경 (디바이스별 성능차 고려)
- (호승님 피드백)클립보드 복사하기 함수 BASEURL을 window.location.origin 으로 변경(개발/배포 환경에 제약없이 주소를 불러와줌)
- (주비님 요청)축제날씨 공용컴포넌트로 분리
- 미사용 콘솔로그들 삭제

### 전달사항
지역날씨정보를 상태에 저장하지않고 리액트 쿼리를 통해 좀 더 빠르고 간결하게 사용 가능 할 것 같다.
아직 익숙하지않아서 익숙한 맛으로 구현했는데, 기능구현 마치고 리팩토링 예정

기상청에서 날씨정보를 업데이트 안해주면 디폴트값으로 종로 날씨가 넘어오는데, 이부분 진영님이 수정해주신다고 함.


![image](https://github.com/Butlers-Team/ticat-client/assets/104641096/79f94072-769a-4ee4-952f-23fe684838f4)
