### PR TITLE
feat : API 요청에 따른 kakao map지도 마커 추가 

### DIFF
--- a/src/api/mapfastival.ts
+++ b/src/api/mapfastival.ts
@@ -5,7 +5,7 @@ import { MapFastivalResponse, MapFastivalRequest } from 'types/api/mapfastival';
 
 /** 2023/07/04 - map 페스티벌 리스트 GET 요청 - by mscojl24 */
 export const getMapFastival = async (params: MapFastivalRequest) => {
-  const { data } = await instance.get<MapFastivalResponse>('/festivals/map', {
+  const { data } = await instance.get<MapFastivalResponse>('/festivals/search', {
     params,
     headers: {
       'No-Auth': true,

--- a/src/api/surroundingfestival.ts
+++ b/src/api/surroundingfestival.ts
@@ -1,0 +1,14 @@
+import instance from './axiosInstance';
+
+// type
+import { surroundTypeResponse, surroundTypeRequest } from 'types/api/surroundingfestival';
+
+/** 2023/07/14 - 같은 카테고리 리스트 GET 요청 - by parksubeom */
+export const getSurroundingFestival = async (params: surroundTypeRequest) => {
+  const { data } = await instance.get<surroundTypeResponse>('/festivals/distance', {
+    params,
+    headers: { 'No-Auth': 'True' },
+  });
+
+  return data;
+};

--- a/src/components/festival/CategoryTabNav.tsx
+++ b/src/components/festival/CategoryTabNav.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { useCategoryTabStore } from '@store/CategoryTabStore';
+import { useCategoryTabStore } from '@store/categoryTabStore';
 
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
 

--- a/src/components/main/CategoryIcon.tsx
+++ b/src/components/main/CategoryIcon.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { useCategoryTabStore } from '@store/CategoryTabStore';
+import { useCategoryTabStore } from '@store/categoryTabStore';
 
 //icon
 import { FaRunning, FaWineGlassAlt, FaCross, FaLightbulb } from 'react-icons/fa';

--- a/src/components/main/MyInfoButton.tsx
+++ b/src/components/main/MyInfoButton.tsx
@@ -32,7 +32,6 @@ const MyInfoButton = () => {
     };
 
     const weather = await getWeather(params);
-    console.log(weather);
     weather && setMyWeather(weather);
     setIsLoading(false); // Weather 데이터를 받아오면 로딩 상태 해제.
   };
@@ -44,7 +43,6 @@ const MyInfoButton = () => {
         position => {
           setLatitude(position.coords.latitude);
           setLongitude(position.coords.longitude);
-          console.log(`위도:${position.coords.latitude} 경도:${position.coords.longitude}`);
         },
         error => {
           console.error('Error getting location:', error);
@@ -89,12 +87,12 @@ const MyInfoButton = () => {
       {isLoading ? (
         <MyInfoCheck bgcolor="var(--color-sub)">
           <li className="flex-v-center column left-section">
-            <span className="font-main">{`현재 집사님의 위치를 조회중 입니다`}</span>
+            <span className="font-main">{`집사님의 위치를 조회중 입니다`}</span>
             <p className="font-sub">{`잠시만 기다려주세요 :)`}</p>
           </li>
           <li className="flex-h-center row width">
             <div className="local-wather-icon">
-              <LodingIcon></LodingIcon>
+              <LodingIcon width="20px" height="20px"></LodingIcon>
             </div>
           </li>
         </MyInfoCheck>

--- a/src/components/maplist/FastivalList.tsx
+++ b/src/components/maplist/FastivalList.tsx
@@ -8,13 +8,19 @@ import Festival from '@components/festival/Festival';
 
 //type
 import { MapFastivalType } from 'types/api/mapfastival';
-import { useOptionStore, useCategoryStore, useKeywordStore } from '@store/mapListStore';
+import { useOptionStore, useCategoryStore, useKeywordStore, useLocationStore } from '@store/mapListStore';
+
+interface transformed {
+  latitude: number;
+  longitude: number;
+}
 
 const FastivalList = () => {
   const [mapListData, setMapListData] = useState<MapFastivalType[]>([]);
   const { sortBy } = useOptionStore();
   const { category } = useCategoryStore();
   const { keyword } = useKeywordStore();
+  const { locationData, setLocationData } = useLocationStore();
 
   const categoryJoin = category.join();
 
@@ -31,6 +37,18 @@ const FastivalList = () => {
     const res = await getMapFastival(params);
     if (res.data) {
       setMapListData(res.data);
+
+      // 변환된 값을 저장할 스테이트 변수
+      const transformedData: transformed[] = [];
+
+      // 주어진 데이터에서 "mapx"와 "mapy" 값을 추출하여 변환 후 스테이트에 저장
+      res.data.forEach(item => {
+        const latitude = item.mapy;
+        const longitude = item.mapx;
+        transformedData.push({ latitude, longitude });
+      });
+
+      setLocationData(transformedData);
     }
   };
   useEffect(() => {

--- a/src/components/maplist/FastivalList.tsx
+++ b/src/components/maplist/FastivalList.tsx
@@ -8,18 +8,20 @@ import Festival from '@components/festival/Festival';
 
 //type
 import { MapFastivalType } from 'types/api/mapfastival';
-import { useOptionStore, useCategoryStore } from '@store/mapListStore';
+import { useOptionStore, useCategoryStore, useKeywordStore } from '@store/mapListStore';
 
 const FastivalList = () => {
   const [mapListData, setMapListData] = useState<MapFastivalType[]>([]);
   const { sortBy } = useOptionStore();
   const { category } = useCategoryStore();
+  const { keyword } = useKeywordStore();
 
   const categoryJoin = category.join();
 
   /** 2023/07/12 - 축제 상세 데이터 요청 함수 - by parksubeom */
   const fetchDetailList = async () => {
     const params = {
+      keyword: keyword,
       categories: categoryJoin,
       sortBy: sortBy,
       page: 1,
@@ -33,7 +35,7 @@ const FastivalList = () => {
   };
   useEffect(() => {
     fetchDetailList();
-  }, [sortBy, category]);
+  }, [sortBy, category, keyword]);
 
   return (
     <FastivalListBox>

--- a/src/components/maplist/MapScreen.tsx
+++ b/src/components/maplist/MapScreen.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
-import { useKeywordStore } from '@store/mapListStore';
+import { useKeywordStore, useLocationStore } from '@store/mapListStore';
 
 //component
 import Button from '@components/Button';
@@ -16,16 +16,19 @@ export interface LatLngType {
 const MapScreen = () => {
   const [inputText, setInputText] = useState<string>('');
   const { setKeyword } = useKeywordStore();
-  const [markerPositions, setMarkerPositions] = useState<LatLngType[]>([
-    { latitude: 37.0, longitude: 127.0 }, // 예시로 두 개의 마커 위치를 초기화
-    { latitude: 37.0, longitude: 127.1 },
-  ]);
+  const { locationData } = useLocationStore();
+  const [markerPositions, setMarkerPositions] = useState<LatLngType[]>(locationData);
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       setKeyword(inputText);
     }
   };
+
+  useEffect(() => {
+    // This useEffect hook will run whenever locationData changes
+    setMarkerPositions(locationData);
+  }, [locationData]);
 
   useEffect(() => {
     // 카카오 지도 API 스크립트가 로드된 후 실행되도록 함
@@ -46,7 +49,7 @@ const MapScreen = () => {
         marker.setMap(map);
       });
     });
-  }, []);
+  }, [markerPositions]);
 
   return (
     <MapView>

--- a/src/components/maplist/MapScreen.tsx
+++ b/src/components/maplist/MapScreen.tsx
@@ -1,4 +1,6 @@
 import styled from 'styled-components';
+import { useState, useEffect } from 'react';
+import { useKeywordStore } from '@store/mapListStore';
 
 //component
 import Button from '@components/Button';
@@ -6,17 +8,74 @@ import Button from '@components/Button';
 //icon
 import { FaSearch } from 'react-icons/fa';
 
+export interface LatLngType {
+  latitude: number;
+  longitude: number;
+}
+
 const MapScreen = () => {
+  const [inputText, setInputText] = useState<string>('');
+  const { setKeyword } = useKeywordStore();
+  const [markerPositions, setMarkerPositions] = useState<LatLngType[]>([
+    { latitude: 37.0, longitude: 127.0 }, // 예시로 두 개의 마커 위치를 초기화
+    { latitude: 37.0, longitude: 127.1 },
+  ]);
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setKeyword(inputText);
+    }
+  };
+
+  useEffect(() => {
+    // 카카오 지도 API 스크립트가 로드된 후 실행되도록 함
+    window.kakao.maps.load(() => {
+      // 카카오 지도 생성
+      const container = document.getElementById('map');
+      const options = {
+        center: new window.kakao.maps.LatLng(37.5665, 126.978), // 서울시청 좌표를 기준으로 설정
+        level: 12, // 지도 확대 레벨
+      };
+      const map = new window.kakao.maps.Map(container, options);
+
+      // 마커들 생성 및 추가
+      markerPositions.forEach(position => {
+        const marker = new window.kakao.maps.Marker({
+          position: new window.kakao.maps.LatLng(position.latitude, position.longitude),
+        });
+        marker.setMap(map);
+      });
+    });
+  }, []);
+
   return (
     <MapView>
+      <div id="map" style={{ width: '100%', height: '100%' }}></div>
       <div className="map-search flex-v-center">
-        <input type="text" placeholder="검색할 축제 이름 및 지역명" />
-        <Button margin="0px" height="40px" width="70px">
+        <input
+          type="text"
+          placeholder="검색할 축제 이름 및 지역명"
+          value={inputText}
+          onChange={e => {
+            setInputText(e.target.value);
+          }}
+          onKeyDown={e => {
+            handleKeyPress(e);
+          }}
+        />
+        <Button
+          margin="0px"
+          height="40px"
+          width="70px"
+          onClick={() => {
+            setKeyword(inputText);
+          }}>
           <FaSearch className="icon-margin" />
           검색
         </Button>
       </div>
-      <img src="https://i.imgur.com/LcydlQy.png" />
+
+      {/* <div className="map-guide"></div> */}
     </MapView>
   );
 };
@@ -34,6 +93,7 @@ const MapView = styled.article`
     width: 100%;
     height: 30px;
     padding: 20px;
+    z-index: 99;
 
     input {
       width: 100%;
@@ -55,9 +115,9 @@ const MapView = styled.article`
       font-size: 1.2rem;
     }
   }
-  img {
+  .map-guide {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    background: url('https://i.imgur.com/LcydlQy.png');
   }
 `;

--- a/src/pages/FestivalListPage.tsx
+++ b/src/pages/FestivalListPage.tsx
@@ -8,7 +8,7 @@ import { CategoriesRequest } from 'types/api/category';
 
 // stores
 import { useAreaFilterStore } from '@store/areaFilterStore';
-import { useCategoryTabStore } from '@store/CategoryTabStore';
+import { useCategoryTabStore } from '@store/categoryTabStore';
 
 // components
 import CatergoryTabNav from '@components/festival/CategoryTabNav';

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 // import { useState } from 'react';
 import { getMainRecommend } from '@api/mainfastival';
+import { getSurroundingFestival } from '@api/surroundingfestival';
 import { MainFastivalType } from 'types/api/mainfastival';
+import { surroundType, surroundTypeRequest } from 'types/api/surroundingfestival';
 
 //components
 import MainSlider from '@components/main/MainSlider';
@@ -32,11 +34,11 @@ const MainPage = () => {
           <CategoryIcon />
         </li>
         <li className="contents-box">
-          <h2>나의 정보 확인</h2>
+          <h2>😀 나의 정보 확인</h2>
           <MyInfoButton />
         </li>
         <li className="contents-box">
-          <h2>추천 축제</h2>
+          <h2>🔥 추천 축제</h2>
           <div>
             <RecommendFestival fastivaldata={recommendData} />
           </div>

--- a/src/pages/MapListPage.tsx
+++ b/src/pages/MapListPage.tsx
@@ -26,6 +26,7 @@ const MapListContainer = styled.section`
 `;
 
 const MapList = styled.article`
+  position: relative;
   background-color: var(--background-color);
   height: calc(100vh - 340px);
   border-radius: 30px 30px 0px 0px;
@@ -33,6 +34,7 @@ const MapList = styled.article`
   overflow: hidden;
   animation: showupLayout 0.5s forwards;
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.2);
+  z-index: 999;
 
   @keyframes showupLayout {
     0% {

--- a/src/store/mapListStore.ts
+++ b/src/store/mapListStore.ts
@@ -56,4 +56,14 @@ const useCategoryStore = create<CategoryState>(set => ({
   },
 }));
 
-export { useOptionStore, useCategoryStore };
+interface keywordState {
+  keyword: string;
+  setKeyword: (keyword: string) => void;
+}
+
+const useKeywordStore = create<keywordState>(set => ({
+  keyword: '',
+  setKeyword: (keyword: string) => set({ keyword }),
+}));
+
+export { useOptionStore, useCategoryStore, useKeywordStore };

--- a/src/store/mapListStore.ts
+++ b/src/store/mapListStore.ts
@@ -66,4 +66,25 @@ const useKeywordStore = create<keywordState>(set => ({
   setKeyword: (keyword: string) => set({ keyword }),
 }));
 
+// 타입 정의
+type Location = {
+  latitude: number;
+  longitude: number;
+};
+
+type LocationDataState = {
+  locationData: Location[];
+  setLocationData: (newData: Location[]) => void;
+};
+
+export const useLocationStore = create<LocationDataState>(set => ({
+  locationData: [
+    {
+      latitude: 127.0,
+      longitude: 25.0,
+    },
+  ],
+  setLocationData: newData => set({ locationData: newData }), // updateData의 인자를 받아 state를 업데이트
+}));
+
 export { useOptionStore, useCategoryStore, useKeywordStore };

--- a/src/types/api/mapfastival.ts
+++ b/src/types/api/mapfastival.ts
@@ -18,6 +18,7 @@ export interface MapFastivalType {
 /**2023/07/23 - 맵 리스트 params (Reqeust) */
 
 export interface MapFastivalRequest {
+  keyword: string;
   categories: string;
   sortBy: string;
   page: number;

--- a/src/types/api/surroundingfestival.ts
+++ b/src/types/api/surroundingfestival.ts
@@ -1,0 +1,29 @@
+/** 2023/07/09 - 주변축제 Type - by mscojl24 */
+export interface surroundType {
+  festivalId: number;
+  status: string;
+  title: string;
+  image: string;
+  address: string;
+  category: string;
+  eventstartdate: string;
+  eventenddate: string;
+  reviewRating: number;
+  reviewCount: number;
+  likeCount: number;
+  area: string;
+  mapx: number;
+  mapy: number;
+}
+
+// 축제 리스트 카테고리별
+/** 2023/07/04 - 주변축제 params (Reqeust) - by mscojl24 */
+export interface surroundTypeRequest {
+  mapX?: number;
+  mapY?: number;
+  distance?: number;
+}
+/** 2023/07/04 - 주변축제 (Response) - by mscojl24 */
+export interface surroundTypeResponse {
+  data: surroundType[];
+}


### PR DESCRIPTION
## Branch
`fe-feat/map-guide-list/#39` -> `dev`


## 변경사항
- [x] map-list API keyword 파람스 추가로 인한 데이터 요청 코드 변경
- [x] API 요청 관련 type 인터페이스 추가
- [x] keyword store 타입 인터페이스 추가
- [x] API 데이터 기준 kakao marker 좌표 변경 함수 추가


## 🖥 차후 추가예정

- 지도 마커 디자인 변경 및 정보 출력 & 라우팅 함수추가
- 사용자 현재 위치 기준 이동 버튼 미구현 
- 현재 위치 기준 키로수에 따른 주변 축제 출력 미구현  (API 요청 코드 구현완료) 
- festival list 컴포넌트 카테고리 출력 부분 -> 사용자 위치 기준 km 수로 변경 미구현


현재 데이터를 받아오는 기능까지만 구현이 완료되어있습니다.
디테일 적인 부분은 메모후 내일중으로 완료 해놓겠습니다! 
