### PR TITLE
feat: 토큰 만료 시간 저장

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './signIn';
 export * from './signUp';
+export * from './refresh';

--- a/src/api/auth/refresh.ts
+++ b/src/api/auth/refresh.ts
@@ -10,10 +10,10 @@ import { ApiRefreshResponse, ApiRefreshHandler } from 'types/auth';
 /** 2023/08/02 - 토근 갱신 요청 - by leekoby */
 export const refreshApi: ApiRefreshHandler = async () => {
   try {
-    const { headers } = await instance.post<ApiRefreshResponse>(`/refresh`);
-    useExpStore.getState().setExp(+dateToSeconds(headers.accesstokenexpiration));
-    useTokenStore.getState().setAccessToken(headers.authorization);
-    return headers;
+    const response = await instance.post<ApiRefreshResponse>(`/refresh`);
+    useExpStore.getState().setExp(+dateToSeconds(response.headers.accesstokenexpiration));
+    useTokenStore.getState().setAccessToken(response.headers.authorization);
+    return response;
   } catch (error) {
     console.error('Failed to refresh token:', error);
     throw error;

--- a/src/api/auth/refresh.ts
+++ b/src/api/auth/refresh.ts
@@ -1,0 +1,21 @@
+import instance from '@api/axiosInstance';
+import { useExpStore } from '@store/useExpStore';
+import { useTokenStore } from '@store/useTokenStore';
+import { dateToSeconds } from '@utils/dateToSeconds';
+
+//type
+import { ApiRefreshResponse, ApiRefreshHandler } from 'types/auth';
+
+//토큰갱신 요청
+/** 2023/08/02 - 토근 갱신 요청 - by leekoby */
+export const refreshApi: ApiRefreshHandler = async () => {
+  try {
+    const { headers } = await instance.post<ApiRefreshResponse>(`/refresh`);
+    useExpStore.getState().setExp(+dateToSeconds(headers.accesstokenexpiration));
+    useTokenStore.getState().setAccessToken(headers.authorization);
+    return headers;
+  } catch (error) {
+    console.error('Failed to refresh token:', error);
+    throw error;
+  }
+};

--- a/src/api/auth/signIn.ts
+++ b/src/api/auth/signIn.ts
@@ -16,5 +16,10 @@ export const apiSignIn: ApiSignInHandler = async ({ id, password }) => {
     },
   );
 
-  return { data, accessToken: headers['authorization'], refreshToken: headers['refresh'] };
+  return {
+    data,
+    accessToken: headers['authorization'],
+    refreshToken: headers['refresh'],
+    accessTokenExpiration: headers['accesstokenexpiration'],
+  };
 };

--- a/src/components/CommonCategoryButton.tsx
+++ b/src/components/CommonCategoryButton.tsx
@@ -1,18 +1,21 @@
 import { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
-interface Props {}
+interface Props {
+  width?: string;
+}
 
 /** 2023/07/19 - 카테고리 버튼 공통 컴포넌트 - by leekoby */
-const CommonCategoryButton: React.FC<PropsWithChildren> = ({ children }): JSX.Element => {
-  return <FastivalCategory>{children}</FastivalCategory>;
+const CommonCategoryButton: React.FC<PropsWithChildren<Props>> = ({ children, width }): JSX.Element => {
+  return <FastivalCategory width={width}>{children}</FastivalCategory>;
 };
 export default CommonCategoryButton;
 
-const FastivalCategory = styled.ul`
+const FastivalCategory = styled.ul<{ width?: string }>`
   display: flex;
   flex-wrap: wrap;
-  width: 300px;
+  /* width: 300px; */
+  width: ${({ width }) => width};
   overflow: hidden;
   border-radius: 10px;
   cursor: auto;
@@ -22,6 +25,7 @@ const FastivalCategory = styled.ul`
     height: 5.5rem;
     border: 1px solid var(--color-dark-gray);
     width: calc(30%);
+    /* width: ${({ width }) => (width ? width : 'calc(30%)')}; */
     padding: 15px 0px;
     font-size: 1.4rem;
     background-color: #fff;

--- a/src/components/CommonCategoryList.tsx
+++ b/src/components/CommonCategoryList.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
-import FastivalCategoryButton from '@components/CommonCategoryButton';
-import FastivalCategoryItem from '@components/CommonCatogoryItem';
+import CommonCategoryButton from '@components/CommonCategoryButton';
+import CommonCatogoryItem from '@components/CommonCatogoryItem';
 import { CategoryOption } from '@utils/categories';
 
 interface Props {
   category: string[];
   handleCategory: (item: string) => void;
+  width?: string;
 }
 /** 2023/07/19 - 카테고리 리스트 공통 컴포넌트 - by leekoby */
 
-const CommonCategoryList: React.FC<Props> = ({ category, handleCategory }): JSX.Element => {
+const CommonCategoryList: React.FC<Props> = ({ category, handleCategory, width }): JSX.Element => {
   return (
-    <FastivalCategoryButton>
+    <CommonCategoryButton width={width}>
       {CategoryOption.map(item => (
-        <FastivalCategoryItem key={item} item={item} category={category} handleCategory={handleCategory} />
+        <CommonCatogoryItem key={item} item={item} category={category} handleCategory={handleCategory} />
       ))}
-    </FastivalCategoryButton>
+    </CommonCategoryButton>
   );
 };
 

--- a/src/components/interest/Category.tsx
+++ b/src/components/interest/Category.tsx
@@ -21,7 +21,7 @@ const CategoryComponent: React.FC<Props> = ({ category, setCategory, onSubmit })
 
   return (
     <>
-      <CommonCategoryList category={category} handleCategory={handleCategory} />
+      <CommonCategoryList category={category} handleCategory={handleCategory} width={'300px'} />
       <ButtonContainer>
         <Button fontSize="1.6rem" disabled={category.length < 1} onClick={onSubmit}>
           <span>확인</span>

--- a/src/hooks/query/useSignIn.ts
+++ b/src/hooks/query/useSignIn.ts
@@ -27,7 +27,6 @@ export const useSignIn = () => {
   const signInMutation = useMutation(apiSignIn, {
     onSuccess: (response: ApiSignInSuccess) => {
       const { accessToken, refreshToken, accessTokenExpiration } = response;
-      console.log('response:', response);
       setExp(+dateToSeconds(accessTokenExpiration));
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -11,6 +11,8 @@ import { GoCodeReview } from 'react-icons/go';
 import MyInfoDescription from '@components/myinfo/MyInfoDescription';
 import MyInfoTabNav from '@components/myinfo/MyInfoTabNav';
 import RecentList from '@components/myinfo/RecentList';
+import { useExpStore } from '@store/useExpStore';
+import { refreshApi } from '@api/auth';
 
 // TabNav Data (label, icon)
 const myInfoTabNav = [
@@ -24,6 +26,24 @@ const myInfoTabNav = [
 const MyPage = () => {
   const [currentTab, setCurrentTab] = useState<string>(myInfoTabNav[0].label);
   const navigate = useNavigate();
+
+  /** 2023/08/02 - 토큰 만료 요청 TEST - by leekoby */
+  /**
+   * TODO: 현재 서버 시간에 문제가 있습니다. 서버에서 응답으로 오는 만료시간이 현재시간보다 9시간 정도 빨라요. 서버에 수정사항이 반영되기 전에 이 주석을 해제하시면 무한요청이 실행되면서 브라우저가 정지되고 서버터질 위험이 있습니다.
+   
+   async function handleExpCheck() {
+    const currentDate = new Date();
+    const currentDateNum = Math.floor(currentDate.getTime() / 1000);
+    const expDataNum = useExpStore().exp;
+    if (expDataNum && expDataNum <= currentDateNum) {
+      const res = await refreshApi({});
+      if (res.status === 200) console.log(res); //성공적으로 갱신되었을때 하고싶은거
+      else navigate('/signin'); // 갱신 실패 로그인 페이지로
+    }
+  }
+  handleExpCheck();
+  
+  */
 
   /** 2023/07/21 - tabNav를 선택하고 변경하는 함수 - by sineTlsl */
   const HandlerSelectTab = (tab: string) => {

--- a/src/store/useExpStore.ts
+++ b/src/store/useExpStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface ExpInfo {
+  exp: number | null;
+  setExp: (exp: number | null) => void;
+  resetExp: () => void;
+}
+
+// 초기값 설정
+const initialState = {
+  exp: null,
+  setExp: () => {},
+  resetExp: () => {},
+};
+
+const resetExp = () => {
+  const { resetExp } = useExpStore.getState();
+  resetExp();
+};
+
+const getExp = () => {
+  const { exp } = useExpStore.getState();
+  return exp;
+};
+
+/** 2023/08/02 - 토큰만료시간 저장소 - by leekoby */
+const useExpStore = create(
+  persist<ExpInfo>(
+    set => ({
+      ...initialState,
+      setExp: exp => set(state => ({ ...state, exp })),
+      resetExp: () => set(() => initialState),
+    }),
+    { name: 'exp', getStorage: () => localStorage },
+  ),
+);
+
+export { useExpStore, resetExp, getExp };

--- a/src/store/useMemberStore.ts
+++ b/src/store/useMemberStore.ts
@@ -24,7 +24,6 @@ const useMemberStore = create(
   persist<MemberInfo>(
     set => ({
       ...initialState,
-      // setMember: member => set(state => ({ ...state, member: member ? { ...state.member, ...member } : null })),
       setMember: member => set(state => ({ ...state, member })),
       resetMember: () => set(() => initialState),
     }),

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -12,3 +12,4 @@ export interface CustomAxiosError extends Omit<AxiosError, 'response'> {
 
 export * from './signIn';
 export * from './signUp';
+export * from './refresh';

--- a/src/types/auth/refresh.ts
+++ b/src/types/auth/refresh.ts
@@ -1,0 +1,11 @@
+// ============================== 토큰 갱신 ==============================
+/** 2023/08/02 - 토큰 갱신 요청 타입 - by leekoby */
+export interface ApiRefreshRequest {}
+
+/** 2023/08/02 - 토큰 갱신 응답 타입 - by leekoby */
+export interface ApiRefreshResponse {}
+
+/** 2023/08/02 - 토큰 갱신 핸들러 - by leekoby */
+export interface ApiRefreshHandler {
+  (body: ApiRefreshRequest): Promise<ApiRefreshResponse>;
+}

--- a/src/types/auth/refresh.ts
+++ b/src/types/auth/refresh.ts
@@ -3,7 +3,9 @@
 export interface ApiRefreshRequest {}
 
 /** 2023/08/02 - 토큰 갱신 응답 타입 - by leekoby */
-export interface ApiRefreshResponse {}
+export interface ApiRefreshResponse {
+  status: number;
+}
 
 /** 2023/08/02 - 토큰 갱신 핸들러 - by leekoby */
 export interface ApiRefreshHandler {

--- a/src/types/auth/signIn.ts
+++ b/src/types/auth/signIn.ts
@@ -12,13 +12,12 @@ export interface ApiSignInRequest {
   password: string;
 }
 /** 2023/07/14 - 로그인 성공 응답 타입 - by leekoby */
-export type ApiSignInSuccess =
-  | {
-      data: ApiSignInResponse;
-      accessToken: string;
-      refreshToken: string;
-    }
-  | unknown;
+export interface ApiSignInSuccess {
+  data: ApiSignInResponse;
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiration: string;
+}
 
 /** 2023/07/07 - 로그인 응답 타입 - by leekoby */
 export type ApiSignInResponse = Member;

--- a/src/utils/dateToSeconds.ts
+++ b/src/utils/dateToSeconds.ts
@@ -1,0 +1,7 @@
+/** 2023/08/02- 토큰 만료시간 변환 함수 - by leekoby */
+export const dateToSeconds = (dateString: string) => {
+  const date = new Date(dateString);
+  const seconds = Math.floor(date.getTime() / 1000);
+
+  return `${seconds}`;
+};


### PR DESCRIPTION
## Branch
`fe-feat/token-expired/#80` -> `dev`

## 중요! 

- ***현재 서버 시간에 문제가 있습니다. 서버에서 응답으로 오는 만료시간이 현재시간보다 9시간 정도 빨라요. 서버에 수정사항이 반영되기 전에 이 주석을 해제하시면 무한요청이 실행되면서 브라우저가 정지되고 서버터질 위험이 있습니다.***
 
- 사용예시 

```ts
   async function handleExpCheck() {
     const currentDate = new Date();
    const currentDateNum = Math.floor(currentDate.getTime() / 1000);
    const expDataNum = useExpStore().exp;
    if (expDataNum && expDataNum <= currentDateNum) {
      const res = await refreshApi({});
      if (res.status === 200) console.log(res); //성공적으로 갱신되었을때 하고싶은거
      else navigate('/signin'); // 갱신 실패 로그인 페이지로
    }
  }
  handleExpCheck();

```


## 변경사항
- 헤더에 담겨오는 토큰 만료시간을 zustand persist를 이용하여 저장. 
- 만료시간이 현재시간 보다 빠르다면 토큰이 만료된 것으로 `refreshApi` 요청으로 토큰을 갱신 받을 수 있음. 
- 성공적으로 갱신되었을 경우 응답 status가 200 이므로 하고 싶은 작업을 진행하면 되고, 
- 이 외에는 실패한 토큰이 만료되었거나 잘못된 접근이므로 로그인 화면으로 리다이렉트할 수 있음. 




## 🖥 전달사항 

- 사용 예시는 예시일뿐 수정해야할 부분이 있으면 알려주세요 
