### PR TITLE
feat : 위치정보 전역관리 + 축제 status 표기 추가 + setting page 로그아웃 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,28 @@
 import { useEffect } from 'react';
 import Router from './Router';
+import { useLocationStore } from '@store/userLocation';
 
 function App() {
+  const setLocation = useLocationStore(state => state.setLocation);
+
   useEffect(() => {
+    /**2023.07.25 사용자 위치정보 요청 - by mscojl24 */
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          const { latitude, longitude } = position.coords;
+          console.log(`위도:${latitude} 경도:${longitude}`);
+          setLocation({ latitude, longitude });
+        },
+        error => {
+          console.error('Error getting location:', error);
+        },
+        {
+          timeout: 5000,
+        },
+      );
+    }
+
     const updateHeight = () => {
       const vh = window.innerHeight * 0.01;
       document.documentElement.style.setProperty('--vh', `${vh}px`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ function App() {
       navigator.geolocation.getCurrentPosition(
         position => {
           const { latitude, longitude } = position.coords;
-          console.log(`위도:${latitude} 경도:${longitude}`);
           setLocation({ latitude, longitude });
         },
         error => {

--- a/src/components/festival/Festival.tsx
+++ b/src/components/festival/Festival.tsx
@@ -13,11 +13,26 @@ interface FestivalProps {
   item: FestivalListType;
 }
 
+const statusStlye = (state: string) => {
+  if (state === 'ONGOING') {
+    return { state: '진행중', style: 'ongoing' };
+  } else if (state === 'COMPLETED') {
+    return { state: '종료됨', style: 'completed' };
+  } else if (state === 'EXPECTED') {
+    return { state: '예정됨', style: 'expected' };
+  }
+  //상태가 명확하지 않을때 출력
+  return { state: '미확인', style: 'completed' };
+};
+
 /** 2023/07/08 - 축제 컴포넌트 - by sineTlsl */
 const Festival = ({ item }: FestivalProps) => {
   return (
     <FestivalContainer>
       <ImgBox>
+        <div className={`festival-status flex-all-center ${statusStlye(item.status).style}`}>
+          {statusStlye(item.status).state}
+        </div>
         {item.image !== '' ? <img src={item.image} /> : <img src="/assets/images/ticat-cover-image.png" />}
       </ImgBox>
       <DescriptionWrap>
@@ -62,6 +77,7 @@ const FestivalContainer = styled.div`
 
 // 축제 정보 이미지
 const ImgBox = styled.div`
+  position: relative;
   flex: 0 0 95px;
   height: 100%;
   width: 100%;
@@ -72,6 +88,28 @@ const ImgBox = styled.div`
     height: 100%;
     object-fit: cover;
     border-radius: 5px;
+  }
+
+  //축제 진행상태
+  .festival-status {
+    position: absolute;
+    top: 10px;
+    left: 0px;
+    width: 50px;
+    color: #fff;
+    border-radius: 4px 0px 4px 0px;
+  }
+
+  .ongoing {
+    background-color: var(--color-main);
+  }
+
+  .completed {
+    background-color: var(--color-dark-gray);
+  }
+
+  .expected {
+    background-color: #5597d4;
   }
 `;
 
@@ -123,7 +161,7 @@ const DescriptionWrap = styled.div`
     gap: 0.2rem;
   }
   > .festival-date {
-    color: var(--color-sub);
+    color: var(--color-dark-gray);
   }
 `;
 

--- a/src/components/main/MyInfoButton.tsx
+++ b/src/components/main/MyInfoButton.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useLocationStore } from '@store/userLocation';
+
 //icon
 import { IoIosArrowForward } from 'react-icons/io';
 import { HiLocationMarker } from 'react-icons/hi';
@@ -20,15 +22,16 @@ interface bgColor {
 
 const MyInfoButton = () => {
   const [myWeather, setMyWeather] = useState<WeatherType>();
-  const [latitude, setLatitude] = useState<number>(0);
-  const [longitude, setLongitude] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const navigate = useNavigate();
+  const { location } = useLocationStore();
+
+  console.log(location);
 
   const myLocationWeather = async () => {
     const params: WeatherRequest = {
-      currentLongitude: longitude,
-      currentLatitude: latitude,
+      currentLongitude: location.longitude,
+      currentLatitude: location.latitude,
     };
 
     const weather = await getWeather(params);
@@ -36,42 +39,16 @@ const MyInfoButton = () => {
     setIsLoading(false); // Weather 데이터를 받아오면 로딩 상태 해제.
   };
 
-  useEffect(() => {
-    /**2023.07.25 사용자 위치정보 요청 - by mscojl24 */
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        position => {
-          setLatitude(position.coords.latitude);
-          setLongitude(position.coords.longitude);
-        },
-        error => {
-          console.error('Error getting location:', error);
-          // 위치 정보를 받아오지 못할경우 디폴트 데이터 출력.
-          setLatitude(126.98834145916423);
-          setLongitude(37.54810058003352);
-          setIsLoading(false);
-        },
-        {
-          timeout: 5000,
-        },
-      );
-    } else {
-      setLatitude(126.98834145916423);
-      setLongitude(37.54810058003352);
-      setIsLoading(false);
-    }
-  }, []);
-
   const navigateStamp = () => {
     navigate(`/stamp/list`);
   };
 
   useEffect(() => {
     // 위치 정보를 가져온 후에 myLocationWeather 함수를 실행합니다.
-    if (latitude && longitude) {
+    if (location) {
       myLocationWeather();
     }
-  }, [latitude, longitude]);
+  }, [location.latitude, location.latitude]);
 
   return (
     <div>

--- a/src/components/main/MyInfoButton.tsx
+++ b/src/components/main/MyInfoButton.tsx
@@ -26,8 +26,6 @@ const MyInfoButton = () => {
   const navigate = useNavigate();
   const { location } = useLocationStore();
 
-  console.log(location);
-
   const myLocationWeather = async () => {
     const params: WeatherRequest = {
       currentLongitude: location.longitude,

--- a/src/components/mysetting/MySetting.tsx
+++ b/src/components/mysetting/MySetting.tsx
@@ -1,0 +1,67 @@
+// import instance from '@api/axiosInstance';
+import styled from 'styled-components';
+
+import { settingData } from '@data/settingData';
+
+const MySetting = () => {
+  return (
+    <SettingBox>
+      {Object.entries(settingData).map(([category, items]) => (
+        <li key={category}>
+          <div className="setting-title flex-h-center">{category}</div>
+          {items.map((item, index) => (
+            <span
+              className="setting-option flex-h-center"
+              key={index}
+              onClick={() => {
+                handelMembershipSetting(item.name);
+              }}>
+              <p>{item.name}</p>
+              <p> {item.subtext} </p>
+            </span>
+          ))}
+        </li>
+      ))}
+    </SettingBox>
+  );
+};
+
+export default MySetting;
+
+const SettingBox = styled.ul`
+  width: 100%;
+  height: calc(100% - 50px);
+  background-color: var(--color-light);
+
+  li:nth-child(1) > div {
+    border-top: 0px;
+  }
+  .setting-title {
+    width: 100%;
+    height: 50px;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 0px 20px;
+    font-size: 1.7rem;
+    font-weight: 700;
+    color: var(--color-main);
+  }
+
+  .setting-option {
+    width: 100%;
+    height: 50px;
+    justify-content: space-between;
+    padding: 0px 20px;
+    font-size: 1.4rem;
+    color: var(--color-dark);
+    cursor: pointer;
+
+    :hover {
+      color: var(--color-main);
+    }
+    :nth-child(2) {
+      color: #ccc;
+    }
+  }
+`;

--- a/src/components/mysetting/MySetting.tsx
+++ b/src/components/mysetting/MySetting.tsx
@@ -4,6 +4,20 @@ import styled from 'styled-components';
 import { settingData } from '@data/settingData';
 
 const MySetting = () => {
+  const handelMembershipSetting = (item: string) => {
+    if (item === '로그아웃') {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      alert('로그아웃이 완료되었습니다');
+      window.location.href = '/main';
+    }
+
+    if (item === '회원탈퇴') {
+      /** 2023/08/08 회원탈퇴 요청 - by mscojl24 */
+      console.log('회원탈퇴 요청좀 도와주실분~');
+    }
+  };
+
   return (
     <SettingBox>
       {Object.entries(settingData).map(([category, items]) => (

--- a/src/data/settingData.ts
+++ b/src/data/settingData.ts
@@ -1,0 +1,22 @@
+type settingDataType = {
+  [key: string]: optionType[];
+};
+
+interface optionType {
+  name: string;
+  subtext: string;
+}
+
+/** 2023/07/13 - 전체 지역 데이터들 - by sineTlsl */
+export const settingData: settingDataType = {
+  계정관리: [
+    { name: '로그아웃', subtext: '' },
+    { name: '회원탈퇴', subtext: '' },
+  ],
+  고객지원: [
+    { name: '버전정보', subtext: '1.0.0 v' },
+    { name: `의견보내기:카카오톡 'TICAT' 검색`, subtext: '' },
+    { name: '공지사항', subtext: '' },
+  ],
+  제작자: [{ name: '버틀러스', subtext: '' }],
+};

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 // import { useState } from 'react';
 import { getMainRecommend } from '@api/mainfastival';
-import { getSurroundingFestival } from '@api/surroundingfestival';
+// import { getSurroundingFestival } from '@api/surroundingfestival';
 import { MainFastivalType } from 'types/api/mainfastival';
-import { surroundType, surroundTypeRequest } from 'types/api/surroundingfestival';
+// import { surroundType, surroundTypeRequest } from 'types/api/surroundingfestival';
 
 //components
 import MainSlider from '@components/main/MainSlider';

--- a/src/pages/SettingPage.tsx
+++ b/src/pages/SettingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 // components
 import TopHistoryBackNav from '@components/TopHistoryBackNav';
+import MySetting from '@components/mysetting/MySetting';
 
 /** 2023/07/21 - 설정 페이지 - by sineTlsl */
 const SettingPage = () => {
@@ -16,6 +17,7 @@ const SettingPage = () => {
   return (
     <SettingContainer>
       <TopHistoryBackNav textTitle="설정 관리" onNavigation={goBackPage} />
+      <MySetting></MySetting>
     </SettingContainer>
   );
 };

--- a/src/store/userLocation.ts
+++ b/src/store/userLocation.ts
@@ -1,0 +1,16 @@
+import create from 'zustand';
+
+interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+interface LocationState {
+  location: Location;
+  setLocation: (location: Location) => void;
+}
+
+export const useLocationStore = create<LocationState>(set => ({
+  location: { latitude: 0, longitude: 0 }, // 초기값 설정
+  setLocation: location => set({ location }),
+}));

--- a/src/store/userLocation.ts
+++ b/src/store/userLocation.ts
@@ -11,6 +11,6 @@ interface LocationState {
 }
 
 export const useLocationStore = create<LocationState>(set => ({
-  location: { latitude: 0, longitude: 0 }, // 초기값 설정
+  location: { latitude: 126.98834145916423, longitude: 37.54810058003352 }, // 초기값 설정
   setLocation: location => set({ location }),
 }));


### PR DESCRIPTION
## Branch
`fe-feat/membership/#84` -> `dev`


## 변경사항
- [x] 사용자 위치정보 전역관리로 변경
- [x] 각 축제 별 status 표기 추가
- [x] setting 컴포넌트 리스트 구현
- [x] 로그아웃 기능구현

## 전달사항

 (+시은님)

```
import { useLocationStore } from '@store/userLocation';


  const { location } = useLocationStore();
  console.log(location);

```

해당코드 입력시 상태값 출력은 아래와같습니다. 필요에 따라 자유롭게 사용해주세요. 

![image](https://github.com/Butlers-Team/ticat-client/assets/119921683/f9e148c0-b759-4698-8736-a6eb7bcc57ad)


![image](https://github.com/Butlers-Team/ticat-client/assets/119921683/e830cb00-b9cf-4571-97d4-9f0feb4ba84d)


회원탈퇴는 요청중 계속 500 상태에러가 해결되지않아 관련코드 삭제후 차후진행예정입니다.
해당부분에서 해결방도가 보이지않아 차후 회의때 논의 해보고싶습니다.