### PR TITLE
refactor : 축제 진행 상태에 따라 캘린더 추가 조건 추가 및 수정

### DIFF
--- a/src/components/calendar/AddCalendarForm.tsx
+++ b/src/components/calendar/AddCalendarForm.tsx
@@ -10,9 +10,19 @@ import { CalendarAddRequest } from 'types/api/addcalendar';
 interface AddCalendarProps {
   setDateForm: React.Dispatch<React.SetStateAction<boolean>>;
   festivalId: number;
+  startdate: string;
+  enddate: string;
 }
 
-const AddCalendar: React.FC<AddCalendarProps> = ({ setDateForm, festivalId }) => {
+const AddCalendar: React.FC<AddCalendarProps> = ({ setDateForm, festivalId, startdate, enddate }) => {
+  const minyear = startdate.substring(0, 4);
+  const minmonth = startdate.substring(4, 6);
+  const minday = startdate.substring(6, 8);
+  const maxyear = enddate.substring(0, 4);
+  const maxmonth = enddate.substring(4, 6);
+  const maxday = enddate.substring(6, 8);
+  const mindate = new Date(`${minyear}-${minmonth}-${minday}`);
+  const maxdate = new Date(`${maxyear}-${maxmonth}-${maxday}`);
   const today = new Date();
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const { member } = useMemberStore();
@@ -46,7 +56,8 @@ const AddCalendar: React.FC<AddCalendarProps> = ({ setDateForm, festivalId }) =>
           id="datePicker"
           selected={selectedDate}
           onChange={handleDateChange}
-          minDate={today}
+          minDate={today > mindate ? today : mindate}
+          maxDate={maxdate}
           dateFormat="yyyy-MM-dd"
           placeholderText="날짜를 선택하세요"
           todayButton="오늘"

--- a/src/components/calendar/ReactCalendar.tsx
+++ b/src/components/calendar/ReactCalendar.tsx
@@ -1,6 +1,7 @@
 import { color } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { FcNext, FcPrevious } from 'react-icons/fc';
 
 interface CalendarProps {
   startDate: Date;
@@ -31,31 +32,11 @@ const ReactCalendar: React.FC<CalendarProps> = ({
       return prevWeekDate;
     });
   };
-  const prevDay = () => {
-    setCurrentDate(prevDate => {
-      const prevWeekDate = new Date(prevDate);
-      prevWeekDate.setDate(prevWeekDate.getDate() - 1);
-      setSelectedDate(prevWeekDate.getDate());
-      setSelectedMonth(prevWeekDate.getMonth());
-      setSelectedYears(prevWeekDate.getFullYear());
-      return prevWeekDate;
-    });
-  };
 
   const nextWeek = () => {
     setCurrentDate(prevDate => {
       const nextWeekDate = new Date(prevDate);
       nextWeekDate.setDate(nextWeekDate.getDate() + 7);
-      setSelectedDate(nextWeekDate.getDate());
-      setSelectedMonth(nextWeekDate.getMonth());
-      setSelectedYears(nextWeekDate.getFullYear());
-      return nextWeekDate;
-    });
-  };
-  const nextDay = () => {
-    setCurrentDate(prevDate => {
-      const nextWeekDate = new Date(prevDate);
-      nextWeekDate.setDate(nextWeekDate.getDate() + 1);
       setSelectedDate(nextWeekDate.getDate());
       setSelectedMonth(nextWeekDate.getMonth());
       setSelectedYears(nextWeekDate.getFullYear());
@@ -109,8 +90,10 @@ const ReactCalendar: React.FC<CalendarProps> = ({
     <div>
       <MonthSelect>{selecteMonth + 1}월</MonthSelect>
       <CalendarSection>
-        <DateSelectBtn onClick={prevWeek}>이전 주</DateSelectBtn>
-        <DateSelectBtn onClick={prevDay}>이전 날</DateSelectBtn>
+        <DateSelectBtn onClick={prevWeek}>
+          <FcPrevious />
+        </DateSelectBtn>
+
         <CalendarWeekTable>
           <CalendarWeekThead>
             <CalendarWeekTr>
@@ -129,8 +112,10 @@ const ReactCalendar: React.FC<CalendarProps> = ({
             <CalendarDayTr>{renderCalendar(selecteDate)}</CalendarDayTr>
           </CalendarDayTbody>
         </CalendarWeekTable>
-        <DateSelectBtn onClick={nextDay}>다음 날</DateSelectBtn>
-        <DateSelectBtn onClick={nextWeek}>다음 주</DateSelectBtn>
+
+        <DateSelectBtn onClick={nextWeek}>
+          <FcNext />
+        </DateSelectBtn>
       </CalendarSection>
     </div>
   );
@@ -174,7 +159,6 @@ const CalendarWeekTr = styled.tr`
 const CalendarDayTbody = styled.tbody`
   font-size: 18px;
   text-align: center;
-  padding-bottom: 20px;
 `;
 const CalendarDayTr = styled.tr`
   display: flex;
@@ -187,7 +171,8 @@ const CalendarDayTr = styled.tr`
 
 const DateSelectBtn = styled.button`
   border: none;
-  font-size: 12px;
+  font-size: 30px;
+  font-weight: bold;
   background-color: transparent;
   cursor: pointer;
 `;

--- a/src/components/detail/FestivalCover.tsx
+++ b/src/components/detail/FestivalCover.tsx
@@ -92,10 +92,17 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
   useEffect(() => {
     fetchWeather();
   }, []);
-
+  console.log(detailList);
   return (
     <CoverContainer>
-      {dateForm && <AddCalendar setDateForm={setDateForm} festivalId={detailList.festivalId} />}
+      {dateForm && (
+        <AddCalendar
+          setDateForm={setDateForm}
+          festivalId={detailList.festivalId}
+          startdate={detailList.eventstartdate}
+          enddate={detailList.eventenddate}
+        />
+      )}
       <img src={defaultImg} onError={ImgErrorHandler}></img>
       <div className="wather-info flex-all-center">
         <span>{regionWeather ? regionWeather.region : 'Loding...'}</span>
@@ -119,12 +126,21 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
           <TiLocation /> {detailList.address}
         </span>
         <BtnSection>
-          <button className="calendar-add-btn" onClick={addCalendar}>
-            캘린더등록
-            <span>
-              <BsCalendarPlus />
-            </span>
-          </button>
+          {detailList.status !== 'COMPLETED' ? (
+            <button className="calendar-add-btn" onClick={addCalendar}>
+              캘린더등록
+              <span>
+                <BsCalendarPlus />
+              </span>
+            </button>
+          ) : (
+            <button className="calendar-disaled-btn" onClick={addCalendar} disabled>
+              캘린더등록
+              <span>
+                <BsCalendarPlus />
+              </span>
+            </button>
+          )}
           <button className="calendar-icon-btn" onClick={LikedHandler}>
             {festivalLiked === true ? <BiSolidHeart /> : <FiHeart />}
           </button>
@@ -221,6 +237,23 @@ const BtnSection = styled.div`
     align-items: center;
     justify-items: space-between;
     background-color: var(--color-main);
+    color: var(--color-light);
+    height: 3.5rem;
+    border-radius: 5px;
+    border: none;
+    font-size: 1.5rem;
+    margin-right: 5px;
+    cursor: pointer;
+    > span {
+      font-size: 16px;
+      margin-left: 2rem;
+    }
+  }
+  > .calendar-disaled-btn {
+    display: flex;
+    align-items: center;
+    justify-items: space-between;
+    background-color: #949090;
     color: var(--color-light);
     height: 3.5rem;
     border-radius: 5px;


### PR DESCRIPTION
## Branch
`fe-feat/CalendarLayout/#10` -> `dev`

## 변경사항
- [x] 종료,예정된 축제의 경우에도 캘린더에 추가되는 엣지케이스 수정
- [x] 진행중인 축제는 현재날짜 - 종료날짜까지 캘린더 추가가능 / 예정된 축제는 시작날짜 - 종료날짜까지 캘린더 추가가능 / 종료된 축제는 캘린더 등록버튼 disabled
- [x] 캘린더 달력 컴포넌트 다음날/이전날 버튼 삭제 / 다음주 이전주 버튼 리액트 아이콘으로 대체.
