### PR TITLE
feat: 티켓 스탬프 캘린더 구현

### DIFF
--- a/src/components/festival/Festival.tsx
+++ b/src/components/festival/Festival.tsx
@@ -25,8 +25,10 @@ const statusStlye = (state: string) => {
   return { state: '미확인', style: 'completed' };
 };
 
-const handlerImgError = () => {
-  return '/assets/images/ticat-cover-image.png';
+/** 2023/09/22 - 이미지 에러 시 기본 이미지로 대체 - by sineTlsl */
+const handlerImgError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.currentTarget;
+  target.src = '/assets/images/ticat-cover-image.png';
 };
 
 /** 2023/07/08 - 축제 컴포넌트 - by sineTlsl */
@@ -37,11 +39,7 @@ const Festival = ({ item }: FestivalProps) => {
         <div className={`festival-status flex-all-center ${statusStlye(item.status).style}`}>
           {statusStlye(item.status).state}
         </div>
-        {item.image !== '' ? (
-          <img src={item.image} alt="" />
-        ) : (
-          <img src="/assets/images/ticat-cover-image.png" alt="" onError={handlerImgError} />
-        )}
+        <img src={item.image || '/assets/images/ticat-cover-image.png'} alt="" onError={handlerImgError} />
       </ImgBox>
       <DescriptionWrap>
         <h3 className="festival-title">{item.title}</h3>

--- a/src/components/festival/Festival.tsx
+++ b/src/components/festival/Festival.tsx
@@ -25,6 +25,10 @@ const statusStlye = (state: string) => {
   return { state: '미확인', style: 'completed' };
 };
 
+const handlerImgError = () => {
+  return '/assets/images/ticat-cover-image.png';
+};
+
 /** 2023/07/08 - 축제 컴포넌트 - by sineTlsl */
 const Festival = ({ item }: FestivalProps) => {
   return (
@@ -33,7 +37,11 @@ const Festival = ({ item }: FestivalProps) => {
         <div className={`festival-status flex-all-center ${statusStlye(item.status).style}`}>
           {statusStlye(item.status).state}
         </div>
-        {item.image !== '' ? <img src={item.image} /> : <img src="/assets/images/ticat-cover-image.png" />}
+        {item.image !== '' ? (
+          <img src={item.image} alt="" />
+        ) : (
+          <img src="/assets/images/ticat-cover-image.png" alt="" onError={handlerImgError} />
+        )}
       </ImgBox>
       <DescriptionWrap>
         <h3 className="festival-title">{item.title}</h3>

--- a/src/components/myinfo/RecentList.tsx
+++ b/src/components/myinfo/RecentList.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getRecentList } from '@api/myinfo';
 
 // components

--- a/src/components/myinfo/RecentList.tsx
+++ b/src/components/myinfo/RecentList.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRecentList } from '@api/myinfo';
 
@@ -12,13 +13,7 @@ interface RecentListProps {
 
 /** 2023/07/23 - 마이페이지 최근 목록 리스트 컴포넌트 - by sineTlsl */
 const RecentList = ({ textTitle }: RecentListProps) => {
-  const queryClient = useQueryClient();
-
-  const { data } = useQuery(['recentList'], getRecentList, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['recentList']);
-    },
-  });
+  const { data } = useQuery(['recentList'], getRecentList, { staleTime: 0 });
 
   return (
     <MyInfoListContainer>

--- a/src/components/myinfo/RecentList.tsx
+++ b/src/components/myinfo/RecentList.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRecentList } from '@api/myinfo';
 
 // components
@@ -12,8 +12,12 @@ interface RecentListProps {
 
 /** 2023/07/23 - 마이페이지 최근 목록 리스트 컴포넌트 - by sineTlsl */
 const RecentList = ({ textTitle }: RecentListProps) => {
+  const queryClient = useQueryClient();
+
   const { data } = useQuery(['recentList'], getRecentList, {
-    refetchInterval: 1000,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['recentList']);
+    },
   });
 
   return (

--- a/src/components/myinfo/RecentListItem.tsx
+++ b/src/components/myinfo/RecentListItem.tsx
@@ -13,16 +13,18 @@ interface RecentListItemProps {
   recentItem: RecentListType;
 }
 
+/** 2023/09/22 - 이미지 에러 시 기본 이미지로 대체 - by sineTlsl */
+const handlerImgError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.currentTarget;
+  target.src = '/assets/images/ticat-cover-image.png';
+};
+
 /** 2023/07/08 - 축제 컴포넌트 - by sineTlsl */
 const RecentListItem = ({ recentItem }: RecentListItemProps) => {
   return (
     <FestivalContainer>
       <ImgWrap>
-        {recentItem.imageUrl !== '' ? (
-          <img src={recentItem.imageUrl} />
-        ) : (
-          <img src="/assets/images/ticat-cover-image.png" />
-        )}
+        <img src={recentItem.imageUrl || '/assets/images/ticat-cover-image.png'} alt="" onError={handlerImgError} />
       </ImgWrap>
       <DescriptionWrap>
         <h3 className="festival-title">{recentItem.title}</h3>

--- a/src/components/stamp/StampCalendar.tsx
+++ b/src/components/stamp/StampCalendar.tsx
@@ -1,5 +1,122 @@
-const StampCalendar = () => {
-  return <></>;
+import styled from 'styled-components';
+import { StampType } from 'types/api/stamp';
+
+interface StampCalendarProps {
+  year: number;
+  month: number;
+  stampList: StampType[];
+}
+
+/** 2023/09/21 - 티캣 스템프 캘린더 컴포넌트 - by sineTlsl */
+const StampCalendar = ({ year, month, stampList }: StampCalendarProps) => {
+  const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
+  const daysInMonth = new Date(year, month, 0).getDate(); // 해당 월의 마지막 날짜
+  const firstDayOfMonth = new Date(year, month - 1, 1).getDay(); // 해당 월의 첫 날의 요일
+
+  const calendarDays = [];
+
+  const stampedDatesSet = new Set(stampList.map(({ stampDate }) => new Date(stampDate).getDate()));
+
+  /** 2023/09/21 - 첫 주의 이전 달 날짜 추가 - by sineTlsl */
+  const lastDayOfLastMonth = new Date(year, month - 1, 0).getDate();
+  for (let i = 0; i < firstDayOfMonth; i++) {
+    const day = lastDayOfLastMonth - firstDayOfMonth + i + 1;
+    calendarDays.unshift(
+      <Day key={`prev-${day}`} $isOtherMonth>
+        {day}
+      </Day>,
+    );
+  }
+
+  /** 2023/09/21 - 현재 달의 날짜 추가 - by sineTlsl */
+  for (let i = 1; i <= daysInMonth; i++) {
+    const isStamped = stampedDatesSet.has(i);
+    const dayOfWeek = (firstDayOfMonth + i - 1) % 7;
+    const isWeekend = dayOfWeek === 0; // 0: 일요일
+
+    calendarDays.push(
+      <Day key={i} $isStamped={isStamped} $isWeekend={isWeekend}>
+        {i}
+      </Day>,
+    );
+  }
+
+  /** 2023/09/21 - 마지막 주의 다음 달 날짜 추가 - by sineTlsl */
+  let nextMonthDay = 1;
+
+  while (calendarDays.length % 7 !== 0) {
+    calendarDays.push(
+      <Day key={`next-${nextMonthDay}`} $isOtherMonth>
+        {nextMonthDay}
+      </Day>,
+    );
+    nextMonthDay += 1;
+  }
+
+  return (
+    <CalendarContainer>
+      <WeekdayGrid>
+        {weekdays.map((day, idx) => (
+          <Weekday key={idx} $isSunday={idx === 0}>
+            {day}
+          </Weekday>
+        ))}
+      </WeekdayGrid>
+      <CalendarGrid>{calendarDays}</CalendarGrid>
+    </CalendarContainer>
+  );
 };
 
 export default StampCalendar;
+
+const CalendarContainer = styled.div`
+  width: calc(100% - 4rem);
+  height: 100%;
+`;
+
+const WeekdayGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin: 2rem 0 1rem 0;
+  text-align: center;
+`;
+
+const Weekday = styled.div<{ $isSunday?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  color: ${props => (props.$isSunday ? '#C72118' : 'var(--color-dark)')};
+  font-weight: 700;
+  padding-bottom: 1rem;
+`;
+
+const CalendarGrid = styled.div`
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  max-height: 230px;
+  height: 100%;
+  grid-template-columns: repeat(7, 1fr); // 7일, 일주일
+`;
+
+const Day = styled.div<{ $isOtherMonth?: boolean; $isStamped?: boolean; $isWeekend?: boolean }>`
+  width: 35px;
+  height: 35px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  background: ${props => (props.$isStamped ? 'var(--color-main)' : 'transparent')};
+  color: ${props =>
+    props.$isStamped
+      ? 'var(--color-light)'
+      : props.$isWeekend
+      ? '#C72118'
+      : props.$isOtherMonth
+      ? 'var(--color-light-gray)'
+      : 'var(--color-dark)'};
+  font-weight: 500;
+  border-radius: 50%;
+  font-size: 14px;
+`;

--- a/src/components/stamp/StampTicket.tsx
+++ b/src/components/stamp/StampTicket.tsx
@@ -7,6 +7,7 @@ import { IoLogoOctocat } from 'react-icons/io';
 
 // util
 import { splitAddress } from '@utils/address';
+import { convertDateFormat } from '@utils/formatDate';
 
 interface StampTicketProps {
   stampList: StampType[];
@@ -18,10 +19,6 @@ interface StampTicketBg {
 /**  2023/06/30 - 스탬프 티켓 컴포넌트 - by sineTlsl */
 const StampTicket = ({ stampList }: StampTicketProps) => {
   const colorBg = ['var(--color-main)', 'var(--color-sub)', '#FF6B6B'];
-  const currentDate = new Date();
-  const formattedDate = `${currentDate.getFullYear()}. ${(currentDate.getMonth() + 1)
-    .toString()
-    .padStart(2, '0')}. ${currentDate.getDate().toString().padStart(2, '0')}`;
 
   return (
     <StampTicketContainer>
@@ -34,7 +31,7 @@ const StampTicket = ({ stampList }: StampTicketProps) => {
                 <MdPlace size="13px" color="var(--color-light)" />
                 <span>{splitAddress(item.address)}</span>
               </p>
-              <p className="item-date">{formattedDate}</p>
+              <p className="item-date">{convertDateFormat(item.stampDate)}</p>
             </ItemText>
             <ItemPhoto>
               <IoLogoOctocat size="50px" color="var(--color-light)" />

--- a/src/components/stamp/StampToggle.tsx
+++ b/src/components/stamp/StampToggle.tsx
@@ -59,19 +59,19 @@ const BtnLabel = styled.label.withConfig({
   }
 
   &::before {
-    content: ${props => (props.isSelectTicket ? "'CALENDAR'" : "'TICKET'")};
+    content: ${props => (props.isSelectTicket ? "'달력'" : "'리스트로 보기'")};
     padding-left: 0.3rem;
-    width: 7rem;
-    left: ${props => (props.isSelectTicket ? '7rem' : '0rem')};
+    width: ${props => (props.isSelectTicket ? '7rem' : '10rem')};
+    left: ${props => (props.isSelectTicket ? '9rem' : '0rem')};
     color: #a7a7a7;
   }
 
   &::after {
-    content: ${props => (props.isSelectTicket ? "'TICKET'" : "'CALENDAR'")};
+    content: ${props => (props.isSelectTicket ? "'리스트로 보기'" : "'달력'")};
     background: #fff;
     font-weight: 700;
-    width: ${props => (props.isSelectTicket ? '7rem' : '9rem')};
-    left: ${props => (props.isSelectTicket ? '0rem' : '7rem')};
+    width: ${props => (props.isSelectTicket ? '10rem' : '7rem')};
+    left: ${props => (props.isSelectTicket ? '0rem' : '10rem')};
     box-shadow: 1px 2px 8px rgba(0, 0, 0, 0.25);
   }
 `;

--- a/src/components/stamp/TicketStamping.tsx
+++ b/src/components/stamp/TicketStamping.tsx
@@ -8,12 +8,18 @@ interface TicketStampingProps {
   item: CalendarListType;
 }
 
+/** 2023/09/22 - 이미지 에러 시 기본 이미지로 대체 - by sineTlsl */
+const handlerImgError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.currentTarget;
+  target.src = '/assets/images/ticat-cover-image.png';
+};
+
 /**  2023/09/17 - 스탬프 찍을 축제 상세 컴포넌트 - by sineTlsl */
 const TicketStamping = ({ item }: TicketStampingProps) => {
   return (
     <TicketStampingContainer>
       <ItemImage>
-        <img src={item.image} />
+        <img src={item.image || '/assets/images/ticat-cover-image.png'} alt="" onError={handlerImgError} />
       </ItemImage>
       <ItemText>
         <p className="item-title">{item.title}</p>

--- a/src/pages/StampListPage.tsx
+++ b/src/pages/StampListPage.tsx
@@ -100,7 +100,12 @@ const StampListPage = () => {
           canGoToLastMonth={canGoToLastMonth}
           canGoToNextMonth={canGoToNextMonth}
         />
-        {data && (isSelectTicket ? <StampTicket stampList={[...data.festivalList].reverse()} /> : <StampCalendar />)}
+        {data &&
+          (isSelectTicket ? (
+            <StampTicket stampList={[...data.festivalList].reverse()} />
+          ) : (
+            <StampCalendar year={year} month={month} stampList={data.festivalList} />
+          ))}
         <div className="toggle-wrap">
           <StampToggle isSelectTicket={isSelectTicket} onClick={handlerToggle} />
         </div>

--- a/src/pages/StampValidPage.tsx
+++ b/src/pages/StampValidPage.tsx
@@ -35,7 +35,7 @@ const StampValidPage = () => {
   const params: StampDistanceRequest = {
     mapX: location.longitude,
     mapY: location.latitude,
-    distance: 300000.0,
+    distance: 300.0,
   };
 
   const { data, isLoading } = useQuery(['stampDistance', params], getStampDistance);

--- a/src/pages/StampValidPage.tsx
+++ b/src/pages/StampValidPage.tsx
@@ -11,6 +11,9 @@ import { CalendarListType } from 'types/api/calendar';
 // api
 import { getStampDistance, postStamp } from '@api/stamp';
 
+// hook
+import useCustomToast from '@hooks/useCustomToast';
+
 // component
 import Button from '@components/Button';
 import StampLocationCheck from '@components/stamp/StampLocationCheck';
@@ -21,6 +24,8 @@ const StampValidPage = () => {
   const navigate = useNavigate();
   const routerLocation = useLocation();
   const queryClient = useQueryClient();
+  const toast = useCustomToast();
+
   const [loading, setLoading] = useState<boolean>(true);
   const [showAlert, setShowAlert] = useState<boolean>(false);
 
@@ -30,7 +35,7 @@ const StampValidPage = () => {
   const params: StampDistanceRequest = {
     mapX: location.longitude,
     mapY: location.latitude,
-    distance: 300.0,
+    distance: 300000.0,
   };
 
   const { data, isLoading } = useQuery(['stampDistance', params], getStampDistance);
@@ -66,11 +71,15 @@ const StampValidPage = () => {
       };
 
       queryClient.invalidateQueries(['getStampList', params]);
-      navigate('/stamp/list');
+      toast({ title: '도장 꾹~! 스탬프 리스트 페이지로 이동합니다 :(', status: 'success' });
+
+      setTimeout(() => {
+        navigate('/stamp/list');
+      }, 2000);
     },
     onError: (err: any) => {
       if (err.response.status === 409) {
-        alert('이미 찍은 스탬프입니다. 다른 축제로 가볼까요?!');
+        toast({ title: '이미 찍은 스탬프입니다.', status: 'error' });
         navigate('/calendar');
       } else {
         console.log(err);

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,3 +2,8 @@
 export const formatDate = (date: string): string => {
   return date.replace(/^(\d{4})(\d{2})(\d{2})$/, '$1.$2.$3');
 };
+
+/** 2023/09/22 - 'YYYY-MM-DD'에서 'YYYY.MM.DD'로 날짜 문자열 형식 지정 - by sineTlsl*/
+export const convertDateFormat = (date: string): string => {
+  return date.replace(/^(\d{4})-(\d{2})-(\d{2})$/, '$1.$2.$3');
+};


### PR DESCRIPTION
## Branch
`fe-feat/stamp/#89` -> `dev`

## 변경사항
- [x] 티켓 스탬프 캘린더 구현
- [x] 마이페이지 최근목록 리렌더링 버그 수정
- [x] 'YYYY-MM-DD'에서 'YYYY.MM.DD'로 날짜 문자열 형식 지정하는 유틸 함수 생성
- [x] 이미지 404일 때, 기본 이미지 처리
- [x]  스탬프 찍었을 때 알림 문구 출력 후, 2초 후 페이지 이동

<p align="center"> 
  <img width="200px"  src="https://github.com/Butlers-Team/ticat-client/assets/97720335/01083f94-309f-415c-a85d-601d346d0f1b">
  <img width="200px"  src="https://github.com/Butlers-Team/ticat-client/assets/97720335/920ca54d-e104-46be-bb07-51af288ee77e">
</p>
