### PR TITLE
feat : 캘린더 리스트 더보기 버튼 통해 무한스크롤 

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -86,7 +86,12 @@ instance.interceptors.response.use(
   /** 2023/07/09 - refresh 로직 추가  - by leekoby */
   async error => {
     const originalRequest = error.config;
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      error.response.data === '엑세스 토큰이 갱신되었습니다.'
+    ) {
+      console.log('error', error);
       originalRequest._retry = true; // 재시도 플래그를 true로 설정
 
       return refreshTokenAndUpdateRequest(error, originalRequest);
@@ -97,9 +102,11 @@ instance.interceptors.response.use(
       clearMember(); // 로컬스토리지 멤버 초기화
       window.location.href = '/signin';
     }
+    clearTokens(); // 로컬스토리지 토큰 초기화
+    clearExp();
+    clearMember(); // 로컬스토리지 멤버 초기화
     // 위의 경우가 아닌 경우 에러를 그대로 반환
     return Promise.reject(error);
   },
 );
-
 export default instance;

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -86,11 +86,11 @@ instance.interceptors.response.use(
   /** 2023/07/09 - refresh 로직 추가  - by leekoby */
   async error => {
     const originalRequest = error.config;
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true; // 재시도 플래그를 true로 설정
 
       return refreshTokenAndUpdateRequest(error, originalRequest);
-    } else if (error.response.status === 401 && originalRequest._retry) {
+    } else if (error.response?.status === 401 && originalRequest._retry) {
       alert('다시 로그인해주세요.');
       clearTokens(); // 로컬스토리지 토큰 초기화
       clearExp();

--- a/src/api/calendar.ts
+++ b/src/api/calendar.ts
@@ -15,6 +15,7 @@ export const getCalendarList = async (params: CalendarListRequest) => {
 export const addCalendarRequest = async ({ ...params }: CalendarAddRequest) => {
   try {
     const { data } = await instance.post<string>(`/calendar/save`, { ...params });
+    alert('성공적으로 추가되었습니다.');
     return data;
   } catch (error: any) {
     if (error.response && error.response.status === 409) {

--- a/src/components/calendar/AddCalendarForm.tsx
+++ b/src/components/calendar/AddCalendarForm.tsx
@@ -44,10 +44,12 @@ const AddCalendar: React.FC<AddCalendarProps> = ({ setDateForm, festivalId, star
   const postForm = () => {
     if (member) {
       setDateForm(false);
+      const endDate = new Date(dateRange.endDate);
+      endDate.setDate(endDate.getDate() + 1);
       const params: CalendarAddRequest = {
         festivalId: festivalId,
         startDate: `${dateRange.startDate?.toJSON().split('T')[0]}`,
-        endDate: `${dateRange.endDate?.toJSON().split('T')[0]}`,
+        endDate: endDate.toISOString().split('T')[0] || '',
       };
       addCalendarRequest(params);
     }

--- a/src/components/calendar/CalendarFestval.tsx
+++ b/src/components/calendar/CalendarFestval.tsx
@@ -69,7 +69,13 @@ const CalendarFestival = ({ item }: FestivalProps) => {
         <FestivalrCategoryWrap>
           <p className="festival-right">{item.category}</p>
         </FestivalrCategoryWrap>
-        <StampAddBtn onClick={routeStampPage}>스탬프찍기</StampAddBtn>
+        {item.status === 'EXPECTED' ? (
+          <DisabledBtn className="disabled" onClick={routeStampPage} disabled>
+            스탬프찍기
+          </DisabledBtn>
+        ) : (
+          <StampAddBtn onClick={routeStampPage}>스탬프찍기</StampAddBtn>
+        )}
         <CalendarDeleteBtn onClick={deleteCalendarList}>삭제</CalendarDeleteBtn>
       </CalendarRightContainer>
     </FestivalContainer>
@@ -184,7 +190,8 @@ const CalendarRightContainer = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-end; /* 수정 */
+  align-items: flex-end; /* 수정 */
   margin-left: auto;
 `;
 
@@ -213,6 +220,7 @@ const CalendarDeleteBtn = styled.button`
   font-size: 12px;
   padding: 0;
   margin-bottom: 20px;
+  font-weight: bold;
   cursor: pointer;
 `;
 
@@ -223,7 +231,21 @@ const StampAddBtn = styled.button`
   background-color: var(--color-main);
   border-radius: 5px;
   font-size: 12px;
+  font-weight: bold;
   padding: 0;
   margin-bottom: 20px;
   cursor: pointer;
+`;
+
+const DisabledBtn = styled.button`
+  width: 60px;
+  height: 20px;
+  border: none;
+  background-color: gray;
+  color: #d2cfcf;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 0;
+  margin-bottom: 20px;
 `;

--- a/src/components/calendar/CalendarFestval.tsx
+++ b/src/components/calendar/CalendarFestval.tsx
@@ -82,7 +82,6 @@ const CalendarFestival = ({ item }: FestivalProps) => {
             <LuStamp />
           </StampAddBtn>
         )}
-        <CalendarDeleteBtn onClick={deleteCalendarList}>삭제</CalendarDeleteBtn>
       </CalendarRightContainer>
     </FestivalContainer>
   );


### PR DESCRIPTION
### Branch
`fe-feat/CalendarLayout/#10` -> `dev`

### 변경사항
- [x] 캘린더 축제리스트 더보기 버튼 추가 및 무한스크롤
- [x] 기간단위로 캘린더 추가 시,endDate 하루 빠지는 현상 수정
- [x] 현재 날짜 이후의 예정된 축제는 스탬프찍기버튼 비활성화
- [x] 캘린더 추가 성공 시, 알림창 추가
- [x] 서비스 이용 중 랜덤하게 발생하는 "status"에러 수정(예상)

### 에로사항
디테일페이지 아이콘이 아이폰에서만깨지는데 
로컬환경에서는 정상으로 나오다보니 조금 더 찾아보고 추가 풀리퀘 올리겠습니다. 
그외 저번회의에서 나온 수정사항은 수정했는데, 피드백사항 말해주시면 저녁전에 반영해볼게요.
그리고 저는status 에러문구를 보고, axiosInstance.ts에서 89번 93번 라인에 
![image](https://github.com/Butlers-Team/ticat-client/assets/104641096/1188f9d1-b0eb-443a-aab4-a0bdd4905217)
이렇게 reponse?로 바꾸니까 에러가 발생하지 않길래 일단 바꿔봤는데 확인 부탁드립니당