### PR TITLE
마이페이지(회원탈퇴, 관심사 수정, 최근목록 좋아요/좋아요 취소) 기능 구현 및 스탬프 페이지 뒤로가기 버그 수정

### DIFF
--- a/src/api/myinfo.ts
+++ b/src/api/myinfo.ts
@@ -18,6 +18,13 @@ export const patchMyInfo = async (body: MyInfoPatchBodyType) => {
   return data;
 };
 
+/** 2023/10/11 - 회원 탈퇴 DELETE 요청 - by sineTlsl */
+export const deleteMember = async () => {
+  const { data } = await instance.delete('/members');
+
+  return data;
+};
+
 // ========================== 축제 최근목록 ==========================
 /** 2023/07/23 - 축제 최근목록 GET 요청 - by sineTlsl */
 export const getRecentList = async () => {

--- a/src/components/main/MyInfoButton.tsx
+++ b/src/components/main/MyInfoButton.tsx
@@ -37,7 +37,7 @@ const MyInfoButton = () => {
   };
 
   const navigateStamp = () => {
-    navigate(`/stamp/list`);
+    navigate('/stamp/list', { state: { page: '/' } });
   };
 
   useEffect(() => {

--- a/src/components/myinfo/RecentList.tsx
+++ b/src/components/myinfo/RecentList.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getRecentList } from '@api/myinfo';
 
@@ -21,9 +20,7 @@ const RecentList = ({ textTitle }: RecentListProps) => {
         <ContentItemWrap>
           {data.map(item => (
             <li key={item.festivalId}>
-              <Link to={`/detail/${item.festivalId}`}>
-                <RecentListItem recentItem={item} />
-              </Link>
+              <RecentListItem recentItem={item} />
             </li>
           ))}
         </ContentItemWrap>

--- a/src/components/myinfo/RecentListItem.tsx
+++ b/src/components/myinfo/RecentListItem.tsx
@@ -1,4 +1,9 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+// hook
+import { usePostFestivalLike } from '@hooks/query/usePostFestivalLike';
+import { usePostFestivalUnLike } from '@hooks/query/usePostFestivalUnLike';
 
 // utils
 import { formatDate } from '@utils/formatDate';
@@ -8,6 +13,7 @@ import { RecentListType } from 'types/api/myinfo';
 // icons
 import { MdPlace } from 'react-icons/md';
 import { TiHeartFullOutline } from 'react-icons/ti';
+import { useState } from 'react';
 
 interface RecentListItemProps {
   recentItem: RecentListType;
@@ -21,23 +27,42 @@ const handlerImgError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
 
 /** 2023/07/08 - 축제 컴포넌트 - by sineTlsl */
 const RecentListItem = ({ recentItem }: RecentListItemProps) => {
+  const postFestivalLike = usePostFestivalLike({ festivalId: recentItem.festivalId });
+  const postFestivalUnLike = usePostFestivalUnLike({ festivalId: recentItem.festivalId });
+  const [itemIsLike, setIsItemLike] = useState<boolean>(recentItem.favorite);
+
+  /** 2023/10/10 - 축제 좋아요/좋아요 취소 - by sineTlsl */
+  const handlerFestivalLike = () => {
+    setIsItemLike(!itemIsLike);
+
+    if (!itemIsLike) {
+      postFestivalLike.mutate();
+    } else {
+      postFestivalUnLike.mutate();
+    }
+  };
+
   return (
     <FestivalContainer>
-      <ImgWrap>
-        <img src={recentItem.imageUrl || '/assets/images/ticat-cover-image.png'} alt="" onError={handlerImgError} />
-      </ImgWrap>
-      <DescriptionWrap>
-        <h3 className="festival-title">{recentItem.title}</h3>
-        <div className="area-wrap">
-          <MdPlace size="13px" color="var(--color-dark)" />
-          <p className="festival-area">{splitAddress(recentItem.address)}</p>
-        </div>
-        <p className="festival-date">
-          {formatDate(recentItem.eventStartDate)} ~ {formatDate(recentItem.eventEndDate)}
-        </p>
-      </DescriptionWrap>
+      <Link className="link-wrap" to={`/detail/${recentItem.festivalId}`}>
+        <ImgWrap>
+          <img src={recentItem.imageUrl || '/assets/images/ticat-cover-image.png'} alt="" onError={handlerImgError} />
+        </ImgWrap>
+        <DescriptionWrap>
+          <h3 className="festival-title">{recentItem.title}</h3>
+          <div className="area-wrap">
+            <MdPlace size="13px" color="var(--color-dark)" />
+            <p className="festival-area">{splitAddress(recentItem.address)}</p>
+          </div>
+          <p className="festival-date">
+            {formatDate(recentItem.eventStartDate)} ~ {formatDate(recentItem.eventEndDate)}
+          </p>
+        </DescriptionWrap>
+      </Link>
       <FestivalLikeWrap>
-        <TiHeartFullOutline size="14px" color={recentItem.favorite ? 'var(--color-sub)' : 'var(--color-light-gray)'} />
+        <button onClick={handlerFestivalLike}>
+          <TiHeartFullOutline size="14px" color={itemIsLike ? 'var(--color-sub)' : 'var(--color-light-gray)'} />
+        </button>
       </FestivalLikeWrap>
     </FestivalContainer>
   );
@@ -48,12 +73,18 @@ export default RecentListItem;
 // 최근 목록 컨테이너
 const FestivalContainer = styled.div`
   display: flex;
-  align-items: center;
   margin: 0 auto;
   width: calc(100% - 4rem);
   height: 105px;
   color: var(--color-dark);
   font-size: 13px;
+
+  > .link-wrap {
+    display: flex;
+    width: calc(100% - 20px);
+    height: 100%;
+    align-items: center;
+  }
 `;
 
 // 이미지
@@ -102,8 +133,15 @@ const DescriptionWrap = styled.div`
 // 축제 좋아요
 const FestivalLikeWrap = styled.div`
   height: 100%;
-  width: 14px;
+  width: 20px;
   display: flex;
   align-items: flex-start;
-  padding-top: 2.5rem;
+  padding-top: 2rem;
+
+  > button {
+    border: none;
+    padding: none;
+    margin: none;
+    background: none;
+  }
 `;

--- a/src/components/mysetting/MySetting.tsx
+++ b/src/components/mysetting/MySetting.tsx
@@ -6,10 +6,16 @@ import { useMemberStore } from '@store/useMemberStore';
 import { useTokenStore } from '@store/useTokenStore';
 import { useExpStore } from '@store/useExpStore';
 
+// hook
+import { useDeleteMember } from '@hooks/query/useDeleteMember';
+
 const MySetting = () => {
   const { clearMember } = useMemberStore();
   const { clearTokens } = useTokenStore();
   const { clearExp } = useExpStore();
+
+  const deleteMemberMutation = useDeleteMember();
+
   const handelMembershipSetting = (item: string) => {
     if (item === '로그아웃') {
       clearMember();
@@ -19,10 +25,8 @@ const MySetting = () => {
       alert('로그아웃이 완료되었습니다');
       window.location.href = '/';
     }
-
     if (item === '회원탈퇴') {
-      /** 2023/08/08 회원탈퇴 요청 - by mscojl24 */
-      // console.log('회원탈퇴 요청좀 도와주실분~');
+      deleteMemberMutation.mutate();
     }
   };
 

--- a/src/hooks/query/useDeleteMember.ts
+++ b/src/hooks/query/useDeleteMember.ts
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+import useCustomToast from '@hooks/useCustomToast';
+
+// api
+import { deleteMember } from '@api/myinfo';
+
+// query
+import { useMutation } from '@tanstack/react-query';
+
+// stroe
+import { useMemberStore } from '@store/useMemberStore';
+import { useTokenStore } from '@store/useTokenStore';
+import { useExpStore } from '@store/useExpStore';
+
+/** 2023/10/11 - 회원 탈퇴 뮤테이션 - by sineTlsl */
+export const useDeleteMember = () => {
+  const toast = useCustomToast();
+  const navigate = useNavigate();
+
+  // store
+  const { clearMember } = useMemberStore();
+  const { clearTokens } = useTokenStore();
+  const { clearExp } = useExpStore();
+
+  const deleteMemberMutation = useMutation(deleteMember, {
+    onSuccess: () => {
+      toast({ title: '회원탈퇴가 되었습니다.', status: 'success' });
+
+      clearMember();
+      clearTokens();
+      clearExp();
+      navigate('/');
+    },
+    onError: () => {
+      toast({ title: '회원탈퇴가 실패했습니다.', status: 'error' });
+    },
+  });
+
+  return deleteMemberMutation;
+};

--- a/src/hooks/query/usePostFestivalLike.ts
+++ b/src/hooks/query/usePostFestivalLike.ts
@@ -1,0 +1,14 @@
+// querys
+import { useMutation } from '@tanstack/react-query';
+
+// api
+import { festivalLikedRequest } from '@api/festivalliked';
+
+interface FestivalLikeProps {
+  festivalId: number;
+}
+
+/** 2023/10/11 - 축제 좋아요 뮤테이션 - by sineTlsl */
+export const usePostFestivalLike = ({ festivalId }: FestivalLikeProps) => {
+  return useMutation(() => festivalLikedRequest(festivalId), {});
+};

--- a/src/hooks/query/usePostFestivalUnLike.ts
+++ b/src/hooks/query/usePostFestivalUnLike.ts
@@ -1,0 +1,14 @@
+// querys
+import { useMutation } from '@tanstack/react-query';
+
+// api
+import { festivalUnLikedRequest } from '@api/festivalliked';
+
+interface FestivalUnLikeProps {
+  festivalId: number;
+}
+
+/** 2023/10/11 - 축제 좋아요 취소 뮤테이션 - by sineTlsl */
+export const usePostFestivalUnLike = ({ festivalId }: FestivalUnLikeProps) => {
+  return useMutation(() => festivalUnLikedRequest(festivalId), {});
+};

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -34,7 +34,7 @@ const MyPage = () => {
     setCurrentTab(tab);
 
     if (tab === '티켓스탬프') {
-      navigate('/stamp/list');
+      navigate('/stamp/list', { state: { page: '/myinfo' } });
     } else if (tab === '정보수정') {
       navigate('/profile', {
         state: { data },

--- a/src/pages/ProfileUpdatePage.tsx
+++ b/src/pages/ProfileUpdatePage.tsx
@@ -102,6 +102,7 @@ const ProfileUpdatePage = () => {
             </ProfileWrap>
           )}
           <CategoryWrap>
+            <p className="category-title">* 관심사는 최대 5개까지 등록 가능합니다.</p>
             <CommonCategoryList width="100%" category={category} handleCategory={handleCategory} />
           </CategoryWrap>
         </ProfileContentWrap>
@@ -163,6 +164,13 @@ const CategoryWrap = styled.div`
   align-items: center;
   justify-content: space-between;
   width: 100%;
+
+  > .category-title {
+    width: 100%;
+    font-size: 13px;
+    color: var(--color-dark-gray);
+    padding-bottom: 1rem;
+  }
 `;
 
 // 회원정보 저장 버튼

--- a/src/pages/SettingPage.tsx
+++ b/src/pages/SettingPage.tsx
@@ -17,7 +17,7 @@ const SettingPage = () => {
   return (
     <SettingContainer>
       <TopHistoryBackNav textTitle="설정 관리" onNavigation={goBackPage} />
-      <MySetting></MySetting>
+      <MySetting />
     </SettingContainer>
   );
 };

--- a/src/pages/StampListPage.tsx
+++ b/src/pages/StampListPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { getStampList } from '@api/stamp';
 import { useQuery } from '@tanstack/react-query';
 import { StampListRequest } from 'types/api/stamp';
@@ -16,6 +16,9 @@ import StampToggle from '@components/stamp/StampToggle';
 const StampListPage = () => {
   // 현재 날짜를 기준으로 캘린더 정의
   const navigate = useNavigate();
+  const routerLocation = useLocation();
+  const goBackPageMode: string = routerLocation.state.page;
+
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
   const currentMonth = currentDate.getMonth() + 1;
@@ -37,7 +40,7 @@ const StampListPage = () => {
 
   /** 2023/07/22 - 이전 페이지 이동 함수 - by sineTlsl */
   const goBackPage = () => {
-    navigate('/myinfo');
+    navigate(goBackPageMode);
   };
 
   /** 2023/07/01 - 토글 클릭 시 상태 전환 - by sineTlsl */

--- a/src/pages/StampValidPage.tsx
+++ b/src/pages/StampValidPage.tsx
@@ -75,7 +75,7 @@ const StampValidPage = () => {
       toast({ title: '도장 꾹~! 스탬프 리스트 페이지로 이동합니다 :(', status: 'success' });
 
       setTimeout(() => {
-        navigate('/stamp/list');
+        navigate('/stamp/list', { state: { page: '/stamp/valid' } });
       }, 2000);
     },
     onError: err => {


### PR DESCRIPTION
### Branch
`fe-feat/fixes/#130` -> `dev`

### 변경사항
- 회원탈퇴 기능 구현
- 마이페이지 최근목록 좋아요/좋아요 취소 기능 구현
- 관심사 최대 5개까지 가능하다는 문구 추가
- 티캣 리스트 페이지 뒤로갈 페이지 라우팅