### PR TITLE
refactor : 캘린더 및 디테일페이지 피드백사항 수정

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -32,7 +32,7 @@ const PublicButton = styled.button<Pick<BtnProps, 'width' | 'height' | 'fontSize
 
   &:disabled {
     color: var(--color-light);
-    opacity: 0.5;
+    opacity: 0.3;
     cursor: not-allowed;
 
     &:hover {
@@ -41,6 +41,6 @@ const PublicButton = styled.button<Pick<BtnProps, 'width' | 'height' | 'fontSize
   }
 
   &:hover {
-    background-color: var(--color-sub);
+    background-color: ${({ color }) => color ?? `var(--color-sub)`};
   }
 `;

--- a/src/components/calendar/CalendarFestval.tsx
+++ b/src/components/calendar/CalendarFestval.tsx
@@ -122,7 +122,6 @@ const FestivalContainer = styled.div`
   height: 105px;
   color: var(--color-dark);
   font-size: 13px;
-  border: solid 0.5px rgba(223, 218, 218, 0.5);
   border-radius: 5px;
 `;
 
@@ -239,20 +238,6 @@ const FestivalrCategoryWrap = styled.div`
 
   @media screen and (max-width: 400px) {
     font-size: 11px;
-  }
-`;
-const CalendarDeleteBtn = styled.button`
-  width: 35px;
-  border: 1px solid #eee;
-  background-color: #ffffff;
-  color: #e62e2e;
-  border-radius: 5px;
-  font-size: 1.4rem;
-  margin-bottom: 5px;
-  cursor: pointer;
-
-  :hover {
-    color: #ff5454;
   }
 `;
 

--- a/src/components/calendar/CalendarFestval.tsx
+++ b/src/components/calendar/CalendarFestval.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from 'react-router-dom';
 // utils
 import { formatDate } from '@utils/formatDate';
 import { splitAddress } from '@utils/address';
-import { deleteCalendarRequest } from '@api/calendar';
 // icons
 import { FaStar } from 'react-icons/fa';
 import { TiHeartFullOutline } from 'react-icons/ti';
@@ -15,7 +14,9 @@ import { LuStamp } from 'react-icons/lu';
 
 interface FestivalProps {
   item: CalendarListType;
-  forceUpdate: React.Dispatch<React.SetStateAction<number>>;
+  deleteSelectedCalendars: () => void;
+  selectedCalendars: number[];
+  setSelectedCalendars: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 const statusStlye = (state: string) => {
@@ -30,9 +31,13 @@ const statusStlye = (state: string) => {
   return { state: '미확인', style: 'completed' };
 };
 
-const CalendarFestival = ({ item, forceUpdate }: FestivalProps) => {
+const CalendarFestival = ({
+  item,
+  deleteSelectedCalendars,
+  selectedCalendars,
+  setSelectedCalendars,
+}: FestivalProps) => {
   const [selected, setSelected] = useState(false);
-  const [selectedCalendars, setSelectedCalendars] = useState<number[]>([]);
   const navigate = useNavigate();
 
   // 수정: 체크박스 클릭 핸들러
@@ -40,7 +45,6 @@ const CalendarFestival = ({ item, forceUpdate }: FestivalProps) => {
     setSelected(prevSelected => {
       const isSelected = selectedCalendars.includes(clickedItem.calendarId);
       let updatedCalendars;
-
       if (isSelected) {
         // 이미 선택된 경우, 배열에서 해당 아이템을 제거합니다.
         updatedCalendars = selectedCalendars.filter(calendar => calendar !== clickedItem.calendarId);
@@ -48,29 +52,9 @@ const CalendarFestival = ({ item, forceUpdate }: FestivalProps) => {
         // 선택되지 않은 경우, 배열에 해당 아이템을 추가합니다.
         updatedCalendars = [...selectedCalendars, clickedItem.calendarId];
       }
-
       setSelectedCalendars(updatedCalendars);
-      console.log(selectedCalendars); // 이 부분에서 아직 업데이트되지 않았을 수 있습니다.
-
       return !prevSelected; // 체크박스 상태를 반전
     });
-  };
-
-  /** 2023/09/12 캘린더 삭제요청 함수 - parksubeom */
-  // 수정: 선택한 캘린더를 삭제하는 함수
-  const deleteSelectedCalendars = async () => {
-    if (selectedCalendars.length === 0) {
-      alert('선택된 캘린더가 없습니다.');
-      return;
-    }
-    // 여기에서 selectedCalendars 배열을 순회하면서 각 캘린더를 삭제하는 요청을 보냅니다.
-    for (const calendar of selectedCalendars) {
-      await deleteCalendarRequest(calendar);
-    }
-    // 삭제 후, 배열 초기화 및 갱신
-    setSelectedCalendars([]);
-    forceUpdate(1);
-    alert('선택한 캘린더가 삭제되었습니다.');
   };
 
   /** 2023/09/12 스탬프페이지로 축제데이터 넘겨주는 함수 - parksubeom */
@@ -122,9 +106,6 @@ const CalendarFestival = ({ item, forceUpdate }: FestivalProps) => {
             <LuStamp />
           </StampAddBtn>
         )}
-        <button onClick={deleteSelectedCalendars}>
-          <CgTrash />
-        </button>
       </CalendarRightContainer>
     </FestivalContainer>
   );
@@ -136,11 +117,14 @@ export default CalendarFestival;
 const FestivalContainer = styled.div`
   display: flex;
   align-items: center;
-  margin: 0 auto;
+  margin: 3px auto;
+  padding: 0px 5px;
   width: 100%;
   height: 105px;
   color: var(--color-dark);
   font-size: 13px;
+  border: solid 0.5px rgba(223, 218, 218, 0.5);
+  border-radius: 5px;
 `;
 
 // 축제 정보 이미지

--- a/src/components/calendar/CalendarFestval.tsx
+++ b/src/components/calendar/CalendarFestval.tsx
@@ -9,14 +9,13 @@ import { splitAddress } from '@utils/address';
 // icons
 import { FaStar } from 'react-icons/fa';
 import { TiHeartFullOutline } from 'react-icons/ti';
-import { CgTrash } from 'react-icons/cg';
 import { LuStamp } from 'react-icons/lu';
 
 interface FestivalProps {
   item: CalendarListType;
-  deleteSelectedCalendars: () => void;
   selectedCalendars: number[];
   setSelectedCalendars: React.Dispatch<React.SetStateAction<number[]>>;
+  select: boolean;
 }
 
 const statusStlye = (state: string) => {
@@ -31,12 +30,7 @@ const statusStlye = (state: string) => {
   return { state: '미확인', style: 'completed' };
 };
 
-const CalendarFestival = ({
-  item,
-  deleteSelectedCalendars,
-  selectedCalendars,
-  setSelectedCalendars,
-}: FestivalProps) => {
+const CalendarFestival = ({ item, select, selectedCalendars, setSelectedCalendars }: FestivalProps) => {
   const [selected, setSelected] = useState(false);
   const navigate = useNavigate();
 
@@ -67,8 +61,8 @@ const CalendarFestival = ({
   };
 
   useEffect(() => {
-    console.log('Updated selectedCalendars:', selectedCalendars);
-  }, [selectedCalendars]);
+    setSelected(false);
+  }, [select]);
   return (
     <FestivalContainer>
       <ImgBox>
@@ -93,20 +87,25 @@ const CalendarFestival = ({
           {formatDate(item.eventStartDate)} ~ {formatDate(item.eventEndDate)}
         </p>
       </DescriptionWrap>
-      <CalendarRightContainer>
-        <FestivalrCategoryWrap>
-          <input type="checkbox" checked={selected} onChange={() => handleCheckboxChange(item)}></input>
-        </FestivalrCategoryWrap>
-        {item.status === 'EXPECTED' ? (
-          <DisabledBtn className="disabled" onClick={routeStampPage} disabled>
-            스탬프찍기
-          </DisabledBtn>
-        ) : (
-          <StampAddBtn onClick={routeStampPage}>
-            <LuStamp />
-          </StampAddBtn>
-        )}
-      </CalendarRightContainer>
+      {select ? (
+        <CalendarRightContainer>
+          <FestivalrCategoryWrap>
+            <input type="checkbox" checked={selected} onChange={() => handleCheckboxChange(item)}></input>
+          </FestivalrCategoryWrap>
+        </CalendarRightContainer>
+      ) : (
+        <CalendarRightContainer>
+          {item.status === 'EXPECTED' ? (
+            <DisabledBtn className="disabled" onClick={routeStampPage} disabled>
+              스탬프찍기
+            </DisabledBtn>
+          ) : (
+            <StampAddBtn onClick={routeStampPage}>
+              <LuStamp />
+            </StampAddBtn>
+          )}
+        </CalendarRightContainer>
+      )}
     </FestivalContainer>
   );
 };

--- a/src/components/calendar/ReactCalendar.tsx
+++ b/src/components/calendar/ReactCalendar.tsx
@@ -5,11 +5,9 @@ import styled from 'styled-components';
 import {
   MdKeyboardArrowLeft,
   MdKeyboardArrowRight,
-  MdKeyboardArrowDown,
   MdOutlineKeyboardDoubleArrowLeft,
   MdOutlineKeyboardDoubleArrowRight,
 } from 'react-icons/md';
-import { BiBorderRadius } from 'react-icons/bi';
 
 interface CalendarProps {
   startDate: Date;

--- a/src/components/calendar/ReactCalendar.tsx
+++ b/src/components/calendar/ReactCalendar.tsx
@@ -224,7 +224,6 @@ const Calendar = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  height: 25%;
   box-shadow: 0px 10px 15px rgb(0, 0, 0, 0.1);
   border-radius: 35px;
   padding: 20px 0px;

--- a/src/components/calendar/ReactCalendar.tsx
+++ b/src/components/calendar/ReactCalendar.tsx
@@ -1,5 +1,4 @@
-// import { background, color } from '@chakra-ui/react';
-
+// 필요한 React 및 라이브러리 import
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import {
@@ -9,6 +8,7 @@ import {
   MdOutlineKeyboardDoubleArrowRight,
 } from 'react-icons/md';
 
+// CalendarProps 인터페이스 정의
 interface CalendarProps {
   startDate: Date;
   setSelectedDate: React.Dispatch<React.SetStateAction<number>>;
@@ -19,6 +19,7 @@ interface CalendarProps {
   selectYears: number;
 }
 
+// ReactCalendar 컴포넌트 정의
 const ReactCalendar: React.FC<CalendarProps> = ({
   startDate,
   setSelectedDate,
@@ -28,21 +29,26 @@ const ReactCalendar: React.FC<CalendarProps> = ({
   selecteMonth,
   selectYears,
 }) => {
+  // 컴포넌트 상태 관리를 위한 useState 훅 사용
   const [currentDate, setCurrentDate] = useState(startDate);
 
+  // 이전 주로 이동하는 함수
   const prevWeek = () => {
     setCurrentDate(prevDate => {
       const prevWeekDate = new Date(prevDate);
       prevWeekDate.setDate(prevWeekDate.getDate() - 7);
+
+      // 이전 주의 월이 현재 선택한 월과 다를 경우, 월을 업데이트
       if (prevWeekDate.getMonth() !== selecteMonth) {
         setSelectedMonth(prevWeekDate.getMonth());
+
+        // 이전 주의 월이 1월인 경우, 연도를 업데이트 (1을 빼서 이전 연도로 변경)
         if (prevWeekDate.getMonth() === 0) {
-          // 0으로 변경
-          setSelectedYears(prevWeekDate.getFullYear() - 1); // 1을 빼서 이전 연도로 변경
+          setSelectedYears(prevWeekDate.getFullYear() - 1);
         }
       }
 
-      // 날짜가 1일 이전으로 넘어갈 경우, 이전 달의 마지막 날짜로 설정합니다.
+      // 날짜가 1일 이전으로 넘어갈 경우, 이전 달의 마지막 날짜로 설정
       if (prevWeekDate.getDate() === 31 && selecteDate === 1) {
         const lastDayOfMonth = new Date(prevWeekDate.getFullYear(), prevWeekDate.getMonth(), 0);
         setSelectedDate(lastDayOfMonth.getDate());
@@ -54,18 +60,23 @@ const ReactCalendar: React.FC<CalendarProps> = ({
     });
   };
 
+  // 다음 주로 이동하는 함수
   const nextWeek = () => {
     setCurrentDate(prevDate => {
       const nextWeekDate = new Date(prevDate);
       nextWeekDate.setDate(nextWeekDate.getDate() + 7);
 
+      // 다음 주의 월이 현재 선택한 월과 다를 경우, 월을 업데이트
       if (nextWeekDate.getMonth() !== selecteMonth) {
         setSelectedMonth(nextWeekDate.getMonth());
+
+        // 다음 주의 월이 1월인 경우, 연도를 업데이트
         if (nextWeekDate.getMonth() === 0) {
           setSelectedYears(nextWeekDate.getFullYear());
         }
       }
-      // 날짜가 다음 달로 넘어갈 경우, 다음 달의 1일로 설정합니다.
+
+      // 날짜가 다음 달로 넘어갈 경우, 다음 달의 1일로 설정
       if (nextWeekDate.getDate() === 1 && selecteDate === 31) {
         setSelectedDate(selecteDate);
       } else {
@@ -75,36 +86,46 @@ const ReactCalendar: React.FC<CalendarProps> = ({
       return nextWeekDate;
     });
   };
+
+  // 날짜를 선택하는 함수
   const selectDay = (date: number) => {
     setCurrentDate(prevDate => {
       const nextWeekDate = new Date(prevDate);
       nextWeekDate.setDate(date);
 
+      // 현재 날짜가 6일보다 작고, 클릭한 날짜가 21보다 크면 (현재달의 초반과 이전달의 후반부가 보이는 캘린더)
       if (selecteDate < 6 && date > 21) {
-        // 현재날짜가 6일보다 작고, 클릭한 날짜가 21보다 클 떄 (현재달의 초반과 이전달의 후반부가 보이는 캘린더)
+        // 현재 월이 1월인 경우
         if (selecteMonth === 0) {
-          // 현재 월이 1월인 경우
-          setSelectedYears(selectYears - 1); // 이전 연도로 변경
-          setSelectedMonth(11); // 12월로 변경
+          // 연도를 이전 연도로 변경
+          setSelectedYears(selectYears - 1);
+          // 월을 12월로 변경
+          setSelectedMonth(11);
         } else {
-          setSelectedMonth(selecteMonth - 1); // 이전 달로 변경
+          // 월을 이전 달로 변경
+          setSelectedMonth(selecteMonth - 1);
         }
       } else if (selecteDate > 22 && date < 6 && selecteDate - date > 6) {
-        //  현재날짜가 22일보다 크고, 클릭한 날짜가 6보다 작을 떄 (현재달의 후반과 이전달의 초반부가 보이는 캘린더)
+        // 현재날짜가 22일보다 크고, 클릭한 날짜가 6보다 작으면 (현재달의 후반과 이전달의 초반부가 보이는 캘린더)
         if (selecteMonth === 11) {
           // 현재 월이 12월인 경우
-          setSelectedYears(selectYears + 1); // 다음 연도로 변경
-          setSelectedMonth(0); // 1월로 변경
+          // 연도를 다음 연도로 변경
+          setSelectedYears(selectYears + 1);
+          // 월을 1월로 변경
+          setSelectedMonth(0);
         } else {
-          setSelectedMonth(selecteMonth + 1); // 다음 달로 변경
+          // 월을 다음 달로 변경
+          setSelectedMonth(selecteMonth + 1);
         }
       }
 
+      // 선택된 날짜 업데이트
       setSelectedDate(date);
       return nextWeekDate;
     });
   };
 
+  // 월을 변경하는 함수
   const changeMonth = (newMonth: number) => {
     let newYear = selectYears;
 
@@ -116,35 +137,33 @@ const ReactCalendar: React.FC<CalendarProps> = ({
       newYear += 1;
     }
 
-    // 변경된 월의 마지막 날짜를 구합니다.
+    // 변경된 월의 마지막 날짜 계산
     const lastDayOfNewMonth = new Date(newYear, newMonth + 1, 0).getDate();
 
     let newDate = selecteDate;
 
-    // 선택된 날짜가 변경된 월의 마지막 날짜보다 큰 경우, 가장 가까운 유효한 날짜로 변경합니다.
+    // 선택된 날짜가 변경된 월의 마지막 날짜보다 큰 경우, 가장 가까운 유효한 날짜로 변경
     if (newDate > lastDayOfNewMonth) {
       newDate = lastDayOfNewMonth;
     }
 
-    // 변경된 월로 날짜 객체를 업데이트합니다.
+    // 변경된 월로 날짜 객체 업데이트
     const adjustedStartDate = new Date(currentDate);
     adjustedStartDate.setMonth(newMonth); // 변경된 월로 설정
     adjustedStartDate.setFullYear(newYear); // 변경된 연도로 설정
-
-    // 선택된 날짜를 업데이트합니다.
     adjustedStartDate.setDate(newDate);
 
-    // state를 업데이트합니다.
+    // 상태 업데이트
     setSelectedDate(newDate);
     setSelectedMonth(newMonth);
     setSelectedYears(newYear);
     setCurrentDate(adjustedStartDate);
   };
 
-  // 날짜 배열 생성 (일요일부터 토요일까지)
+  // 일요일부터 토요일까지의 요일 배열
   const weekdays = ['일', '월', '화', '수', '목', '금', '토'];
 
-  // 캘린더의 렌더링 로직
+  // 캘린더를 렌더링하는 함수
   const renderCalendar = (selecteDate: number) => {
     const weekStart = new Date(currentDate);
     weekStart.setDate(weekStart.getDate() - weekStart.getDay());
@@ -155,10 +174,10 @@ const ReactCalendar: React.FC<CalendarProps> = ({
       const date = new Date(weekStart);
       date.setDate(weekStart.getDate() + i);
 
-      // 현재 날짜와 selectDate를 비교하여 스타일을 변경.
+      // 현재 날짜와 selectDate를 비교하여 스타일을 변경
       const isCurrentDate = date.getDate() === selecteDate;
 
-      // 스타일을 파란색으로 변경합니다.
+      // 스타일을 파란색으로 변경
       const cellStyle = isCurrentDate
         ? { color: 'var(--color-main)', background: '#E4F4FF', borderRadius: '20px' }
         : {};
@@ -172,6 +191,7 @@ const ReactCalendar: React.FC<CalendarProps> = ({
     return calendar;
   };
 
+  // 컴포넌트의 반환
   return (
     <Calendar>
       <MonthSelect>
@@ -212,6 +232,8 @@ const ReactCalendar: React.FC<CalendarProps> = ({
     </Calendar>
   );
 };
+
+// ReactCalendar 컴포넌트 내보내기
 export default ReactCalendar;
 
 const Calendar = styled.div`

--- a/src/components/calendar/ReactCalendar.tsx
+++ b/src/components/calendar/ReactCalendar.tsx
@@ -91,7 +91,7 @@ const ReactCalendar: React.FC<CalendarProps> = ({
         } else {
           setSelectedMonth(selecteMonth - 1); // 이전 달로 변경
         }
-      } else if (selecteDate > 22 && date < 6) {
+      } else if (selecteDate > 22 && date < 6 && selecteDate - date > 6) {
         //  현재날짜가 22일보다 크고, 클릭한 날짜가 6보다 작을 떄 (현재달의 후반과 이전달의 초반부가 보이는 캘린더)
         if (selecteMonth === 11) {
           // 현재 월이 12월인 경우
@@ -189,7 +189,6 @@ const ReactCalendar: React.FC<CalendarProps> = ({
         <DateSelectBtn onClick={prevWeek} className="arr-icons-color">
           <MdKeyboardArrowLeft />
         </DateSelectBtn>
-
         <CalendarWeekTable>
           <CalendarWeekThead>
             <CalendarWeekTr>
@@ -208,7 +207,6 @@ const ReactCalendar: React.FC<CalendarProps> = ({
             <CalendarDayTr>{renderCalendar(selecteDate)}</CalendarDayTr>
           </CalendarDayTbody>
         </CalendarWeekTable>
-
         <DateSelectBtn onClick={nextWeek} className="arr-icons-color">
           <MdKeyboardArrowRight />
         </DateSelectBtn>

--- a/src/components/detail/FestivalCover.tsx
+++ b/src/components/detail/FestivalCover.tsx
@@ -7,8 +7,7 @@ import { getWeather } from '@api/weather';
 import { WeatherRequest, WeatherType } from 'types/api/weather';
 import { WeatherIcon } from '@components/WeatherIcon';
 import AddCalendar from '@components/calendar/AddCalendarForm';
-//import { getToken } from '@store/useTokenStore';
-
+import { CalendarListType2 } from 'types/api/calendar';
 //icon
 import { TiLocation } from 'react-icons/ti';
 import { LuStamp } from 'react-icons/lu';
@@ -96,10 +95,27 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
   const addCalendar = () => {
     setDateForm(!dateForm);
   };
-
   const routeStampPage = () => {
-    //navigate('/stamp/valid', { state: { detailList } });
-    console.log(detailList);
+    const item: CalendarListType2 = {
+      address: detailList.address,
+      category: detailList.category,
+      eventEndDate: detailList.eventenddate,
+      eventhomepage: detailList.eventhomepage,
+      eventplace: detailList.eventplace,
+      eventStartDate: detailList.eventstartdate,
+      festivalId: detailList.festivalId,
+      image: detailList.image,
+      liked: detailList.liked,
+      mapx: detailList.mapx,
+      mapy: detailList.mapy,
+      overview: detailList.overview,
+      playtime: detailList.playtime,
+      price: detailList.price,
+      status: detailList.status,
+      tel: detailList.tel,
+      title: detailList.title,
+    };
+    navigate('/stamp/valid', { state: { item } });
   };
 
   useEffect(() => {

--- a/src/components/detail/FestivalCover.tsx
+++ b/src/components/detail/FestivalCover.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+
 import { festivalLikedRequest, festivalUnLikedRequest } from '@api/festivalliked';
 import { getWeather } from '@api/weather';
 import { WeatherRequest, WeatherType } from 'types/api/weather';
@@ -10,6 +11,7 @@ import AddCalendar from '@components/calendar/AddCalendarForm';
 
 //icon
 import { TiLocation } from 'react-icons/ti';
+import { LuStamp } from 'react-icons/lu';
 import { BiSolidHeart } from 'react-icons/bi';
 import { FiHeart, FiShare2 } from 'react-icons/fi';
 import { LuTicket } from 'react-icons/lu';
@@ -28,6 +30,7 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
   const isAuthenticated = !!accessToken && !!refreshToken;
   const token = window.localStorage.getItem('accessToken');
   const location = useLocation();
+  const navigate = useNavigate();
   const [dateForm, setDateForm] = useState<boolean>(false);
   const [defaultImg, setDefaultImg] = useState(detailList.image);
   const [festivalLiked, setFestivalLiked] = useState(detailList.liked);
@@ -94,6 +97,11 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
     setDateForm(!dateForm);
   };
 
+  const routeStampPage = () => {
+    //navigate('/stamp/valid', { state: { detailList } });
+    console.log(detailList);
+  };
+
   useEffect(() => {
     fetchWeather();
   }, []);
@@ -157,6 +165,10 @@ const FestivalCover: React.FC<FestivalCoverProps> = ({ detailList }) => {
             className="calendar-icon-btn"
             onClick={() => handleCopyClipBoard(`${window.location.origin}${location.pathname}`)}>
             <FiShare2 />
+          </button>
+
+          <button className="calendar-icon-btn" onClick={routeStampPage}>
+            <LuStamp />
           </button>
         </BtnSection>
       </div>

--- a/src/components/detail/FestivalLocation.tsx
+++ b/src/components/detail/FestivalLocation.tsx
@@ -40,7 +40,11 @@ const FestivalLocation: React.FC<FestivalCoverProps> = ({ detailList }) => {
   }, []);
   /** 2023/07/23 - 카카오맵에서 축제위치와 내 위치의 경로를 찾도록 링크로 이동시켜주는 함수 - by parksubeom */
   const searchKakaoMap = () => {
-    window.open(`https://map.kakao.com/link/to/${detailList.eventplace},${detailList.mapy},${detailList.mapx}`);
+    window.open(
+      `https://map.kakao.com/link/to/${detailList.eventplace === '' ? detailList.address : detailList.eventplace},${
+        detailList.mapy
+      },${detailList.mapx}`,
+    );
   };
   return (
     <>

--- a/src/components/stamp/TicketStamping.tsx
+++ b/src/components/stamp/TicketStamping.tsx
@@ -1,11 +1,11 @@
 import styled, { keyframes } from 'styled-components';
-import { CalendarListType } from 'types/api/calendar';
+import { CalendarListType2 } from 'types/api/calendar';
 
 // icons
 import { MdPlace } from 'react-icons/md';
 
 interface TicketStampingProps {
-  item: CalendarListType;
+  item: CalendarListType2;
 }
 
 /** 2023/09/22 - 이미지 에러 시 기본 이미지로 대체 - by sineTlsl */

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -108,7 +108,9 @@ export default CalendarPage;
 const CalendarContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 80vh;
+  height: calc(100vh - 70px);
+  display: flex;
+  flex-direction: column;
   .today-date {
     font-size: 16px;
     margin: 0 2rem;
@@ -127,6 +129,7 @@ const FestivalListSection = styled.section`
   align-items: center;
   justify-content: center;
   width: 100%;
+  height: 100vh;
   overflow: hidden;
 `;
 /** 2023/07/02 - 추가된 축제리스트가 없을 때 보여지는 섹션  - by parksubeom */

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 import { useState, useEffect, useReducer } from 'react';
 import ReactCalendar from '@components/calendar/ReactCalendar';
-import { CalendarListRequest, CalendarListListType, CalendarListType } from 'types/api/calendar';
+import { CalendarListRequest, CalendarListType } from 'types/api/calendar';
 import { getCalendarList } from '@api/calendar';
 import CalendarFestival from '@components/calendar/CalendarFestval';
 import { deleteCalendarRequest } from '@api/calendar';
 import Button from '@components/Button';
-import { CgTrash } from 'react-icons/cg';
+
 const CalendarPage: React.FC = (): JSX.Element => {
   const now = new Date();
   const year = now.getFullYear();
@@ -86,7 +86,6 @@ const CalendarPage: React.FC = (): JSX.Element => {
     };
     MoreCalendarList();
   }, [page]);
-  console.log(selectedCalendars); // 이 부분에서 아직 업데이트되지 않았을 수 있습니다.
   return (
     <CalendarContainer>
       <CalendarSection>
@@ -123,7 +122,7 @@ const CalendarPage: React.FC = (): JSX.Element => {
       </CalendarTopSection>
 
       <FestivalListSection>
-        {calendarDatailList?.length === undefined || calendarDatailList.length < 1 ? (
+        {calendarDatailList.length < 1 ? (
           <EmptyListSection>
             <img src={'assets/images/ticat-logo-icon-gray.png'}></img>
             <span>추가된 축제 일정이 없어요.</span>
@@ -242,7 +241,6 @@ const FestivalScrollWrap = styled.div`
   overflow: auto;
   margin: 0 auto;
 
-  // 스크롤바 없애기
   // chrome and safari
   ::-webkit-scrollbar {
     display: none;

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -261,8 +261,8 @@ const DeleteBtnSection = styled.div`
     border-radius: 5px;
     font-size: 12px;
     font-weight: bold;
-    color: #ff5454;
-    border: 1px solid #ff5454;
+    color: #787474;
+    border: 1px solid #eee;
     box-shadow: none;
     background-color: var(--background-color);
   }
@@ -272,8 +272,8 @@ const DeleteBtnSection = styled.div`
     border-radius: 5px;
     font-size: 12px;
     font-weight: bold;
-    color: #787474;
-    border: 1px solid #eee;
+    color: #ff5454;
+    border: 1px solid #ff5454;
     background-color: #ffffff;
     box-shadow: none;
     background-color: var(--background-color);

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -4,12 +4,15 @@ import ReactCalendar from '@components/calendar/ReactCalendar';
 import { CalendarListRequest, CalendarListListType, CalendarListType } from 'types/api/calendar';
 import { getCalendarList } from '@api/calendar';
 import CalendarFestival from '@components/calendar/CalendarFestval';
+import { deleteCalendarRequest } from '@api/calendar';
 import Button from '@components/Button';
+import { CgTrash } from 'react-icons/cg';
 const CalendarPage: React.FC = (): JSX.Element => {
   const now = new Date();
   const year = now.getFullYear();
   const month = now.getMonth();
   const date = now.getDate();
+  const [selectedCalendars, setSelectedCalendars] = useState<number[]>([]);
   const [page, setPage] = useState<number>(1);
   const [totalPages, setTotalPages] = useState<number>();
   const [selecteDate, setSelectedDate] = useState<number>(date);
@@ -42,6 +45,23 @@ const CalendarPage: React.FC = (): JSX.Element => {
     fetchCalendarList();
   }, [selecteDate, selecteMonth, selecteYears, trigger]);
 
+  /** 2023/09/12 캘린더 삭제요청 함수 - parksubeom */
+  // 수정: 선택한 캘린더를 삭제하는 함수
+  const deleteSelectedCalendars = async () => {
+    if (selectedCalendars.length === 0) {
+      alert('선택된 캘린더가 없습니다.');
+      return;
+    }
+    // 여기에서 selectedCalendars 배열을 순회하면서 각 캘린더를 삭제하는 요청을 보냅니다.
+    for (const calendar of selectedCalendars) {
+      await deleteCalendarRequest(calendar);
+    }
+    // 삭제 후, 배열 초기화 및 갱신
+    setSelectedCalendars([]);
+    forceUpdate();
+    alert('선택한 캘린더가 삭제되었습니다.');
+  };
+
   const handleLoadMore = () => {
     setPage(prevPage => prevPage + 1);
   };
@@ -61,6 +81,7 @@ const CalendarPage: React.FC = (): JSX.Element => {
     };
     MoreCalendarList();
   }, [page]);
+  console.log(selectedCalendars); // 이 부분에서 아직 업데이트되지 않았을 수 있습니다.
   return (
     <CalendarContainer>
       <CalendarSection>
@@ -89,10 +110,22 @@ const CalendarPage: React.FC = (): JSX.Element => {
           </EmptyListSection>
         ) : (
           <FestivalScrollWrap>
+            <DeleteBtnSection>
+              {' '}
+              <button onClick={() => deleteSelectedCalendars()}>
+                <CgTrash />
+              </button>
+            </DeleteBtnSection>
+
             {calendarDatailList?.map(festival => {
               return (
                 <li key={festival.festivalId}>
-                  <CalendarFestival item={festival} forceUpdate={forceUpdate} />
+                  <CalendarFestival
+                    item={festival}
+                    selectedCalendars={selectedCalendars}
+                    setSelectedCalendars={setSelectedCalendars}
+                    deleteSelectedCalendars={deleteSelectedCalendars}
+                  />
                 </li>
               );
             })}
@@ -179,8 +212,25 @@ const FestivalScrollWrap = styled.div`
   }
   // firefox
   scrollbar-width: none;
-
   @media screen and (max-width: 400px) {
     height: calc(100% - 11rem);
+  }
+`;
+const DeleteBtnSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: right;
+  margin: 0;
+  > button {
+    width: 8rem;
+    height: 3rem;
+    border-radius: 10px;
+    font-weight: bold;
+    color: red;
+    border: 2px solid red;
+    box-shadow: none;
+    background-color: var(--background-color);
+    margin-top: 1rem;
   }
 `;

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -104,20 +104,24 @@ const CalendarPage: React.FC = (): JSX.Element => {
         <p className="today-date">
           <span>{selecteYears}년</span> <span>{selecteMonth + 1}월</span> <span>{selecteDate}일</span> 축제리스트
         </p>
-        {select ? (
-          <DeleteBtnSection>
-            {' '}
-            <button className="select-list" onClick={() => selectDeleteList()}>
-              선택취소
-            </button>
-          </DeleteBtnSection>
-        ) : (
-          <DeleteBtnSection>
-            {' '}
-            <button className="unselect-list" onClick={() => selectDeleteList()}>
-              선택삭제
-            </button>
-          </DeleteBtnSection>
+        {calendarDatailList.length > 0 && (
+          <div>
+            {select ? (
+              <DeleteBtnSection>
+                {' '}
+                <button className="select-list" onClick={() => selectDeleteList()}>
+                  선택취소
+                </button>
+              </DeleteBtnSection>
+            ) : (
+              <DeleteBtnSection>
+                {' '}
+                <button className="unselect-list" onClick={() => selectDeleteList()}>
+                  선택삭제
+                </button>
+              </DeleteBtnSection>
+            )}
+          </div>
         )}
       </CalendarTopSection>
 

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -13,6 +13,7 @@ const CalendarPage: React.FC = (): JSX.Element => {
   const month = now.getMonth();
   const date = now.getDate();
   const [selectedCalendars, setSelectedCalendars] = useState<number[]>([]);
+  const [select, setSelect] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
   const [totalPages, setTotalPages] = useState<number>();
   const [selecteDate, setSelectedDate] = useState<number>(date);
@@ -43,10 +44,14 @@ const CalendarPage: React.FC = (): JSX.Element => {
     };
     setPage(1);
     fetchCalendarList();
+    setSelectedCalendars([]);
+    setSelect(false);
   }, [selecteDate, selecteMonth, selecteYears, trigger]);
-
+  const selectDeleteList = () => {
+    setSelect(!select);
+    setSelectedCalendars([]);
+  };
   /** 2023/09/12 캘린더 삭제요청 함수 - parksubeom */
-  // 수정: 선택한 캘린더를 삭제하는 함수
   const deleteSelectedCalendars = async () => {
     if (selectedCalendars.length === 0) {
       alert('선택된 캘린더가 없습니다.');
@@ -95,10 +100,28 @@ const CalendarPage: React.FC = (): JSX.Element => {
           selectYears={selecteYears}
         />
       </CalendarSection>
+      <CalendarTopSection>
+        {' '}
+        <p className="today-date">
+          <span>{selecteYears}년</span> <span>{selecteMonth + 1}월</span> <span>{selecteDate}일</span> 축제리스트
+        </p>
+        {select ? (
+          <DeleteBtnSection>
+            {' '}
+            <button className="select-list" onClick={() => selectDeleteList()}>
+              선택취소
+            </button>
+          </DeleteBtnSection>
+        ) : (
+          <DeleteBtnSection>
+            {' '}
+            <button className="unselect-list" onClick={() => selectDeleteList()}>
+              선택삭제
+            </button>
+          </DeleteBtnSection>
+        )}
+      </CalendarTopSection>
 
-      <p className="today-date">
-        <span>{selecteYears}년</span> <span>{selecteMonth + 1}월</span> <span>{selecteDate}일</span> 축제리스트
-      </p>
       <FestivalListSection>
         {calendarDatailList?.length === undefined || calendarDatailList.length < 1 ? (
           <EmptyListSection>
@@ -110,13 +133,6 @@ const CalendarPage: React.FC = (): JSX.Element => {
           </EmptyListSection>
         ) : (
           <FestivalScrollWrap>
-            <DeleteBtnSection>
-              {' '}
-              <button onClick={() => deleteSelectedCalendars()}>
-                <CgTrash />
-              </button>
-            </DeleteBtnSection>
-
             {calendarDatailList?.map(festival => {
               return (
                 <li key={festival.festivalId}>
@@ -124,11 +140,25 @@ const CalendarPage: React.FC = (): JSX.Element => {
                     item={festival}
                     selectedCalendars={selectedCalendars}
                     setSelectedCalendars={setSelectedCalendars}
-                    deleteSelectedCalendars={deleteSelectedCalendars}
+                    select={select}
                   />
                 </li>
               );
             })}
+            {select && selectedCalendars.length > 0 ? (
+              <Button
+                color="#ff5454"
+                onClick={
+                  deleteSelectedCalendars
+                }>{`선택한 리스트 삭제 ${selectedCalendars.length}/${calendarDatailList.length}`}</Button>
+            ) : select ? (
+              <Button
+                disabled
+                color="#ff5454;"
+                onClick={
+                  deleteSelectedCalendars
+                }>{`선택한 리스트 삭제 ${selectedCalendars.length}/${calendarDatailList.length}`}</Button>
+            ) : null}
             {totalPages === calendarDatailList.length ? null : <Button onClick={handleLoadMore}>축제 더보기</Button>}
           </FestivalScrollWrap>
         )}
@@ -153,6 +183,11 @@ const CalendarContainer = styled.div`
     }
   }
 `;
+const CalendarTopSection = styled.section`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;
 /** 2023/07/02 - 축제 캘린더 섹션  - by parksubeom */
 const CalendarSection = styled.section``;
 /** 2023/07/02 - 축제 리스트 섹션  - by parksubeom */
@@ -164,6 +199,7 @@ const FestivalListSection = styled.section`
   width: 100%;
   height: 100vh;
   overflow: hidden;
+  margin-top: 2rem;
 `;
 /** 2023/07/02 - 추가된 축제리스트가 없을 때 보여지는 섹션  - by parksubeom */
 const EmptyListSection = styled.section`
@@ -200,11 +236,12 @@ const EmptyListSection = styled.section`
   }
 `;
 const FestivalScrollWrap = styled.div`
-  height: calc(100% - 100px);
+  height: 100%;
   width: 100%;
   padding: 20px;
   overflow: auto;
   margin: 0 auto;
+
   // 스크롤바 없애기
   // chrome and safari
   ::-webkit-scrollbar {
@@ -212,25 +249,35 @@ const FestivalScrollWrap = styled.div`
   }
   // firefox
   scrollbar-width: none;
-  @media screen and (max-width: 400px) {
-    height: calc(100% - 11rem);
-  }
 `;
 const DeleteBtnSection = styled.div`
-  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: right;
-  margin: 0;
-  > button {
-    width: 8rem;
-    height: 3rem;
-    border-radius: 10px;
+  margin: 0 2rem;
+  margin-top: 2rem;
+
+  > .select-list {
+    width: 6rem;
+    height: 2.5rem;
+    border-radius: 5px;
+    font-size: 12px;
     font-weight: bold;
-    color: red;
-    border: 2px solid red;
+    color: #ff5454;
+    border: 1px solid #ff5454;
     box-shadow: none;
     background-color: var(--background-color);
-    margin-top: 1rem;
+  }
+  > .unselect-list {
+    width: 6rem;
+    height: 2.5rem;
+    border-radius: 5px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #787474;
+    border: 1px solid #eee;
+    background-color: #ffffff;
+    box-shadow: none;
+    background-color: var(--background-color);
   }
 `;

--- a/src/types/api/calendar.ts
+++ b/src/types/api/calendar.ts
@@ -60,6 +60,26 @@ export interface CalendarListType {
   calendarDate: string;
 }
 
+export interface CalendarListType2 {
+  address: string;
+  category: string;
+  eventEndDate: string;
+  eventhomepage: string;
+  eventplace: string;
+  eventStartDate: string;
+  festivalId: number;
+  image: string;
+  liked: boolean;
+  mapx: number;
+  mapy: number;
+  overview: string;
+  playtime: string;
+  price: string;
+  status: string;
+  tel: string;
+  title: string;
+}
+
 // 축제 리스트 카테고리별
 /** 2023/07/04 - 축제 리스트 카테고리별 params (Reqeust) - by  parksubeom */
 export interface CalendarListRequest {


### PR DESCRIPTION
## Branch
`fe-feat/CalendarLayout/#10` -> `dev`

## 변경사항
- [x] 캘린더 리스트 없을 때,안내문구 센터링
- [x] 캘린더 선택삭제 버튼을 통해 다중삭제 기능 구현
- [x] 디테일페이지에서 스탬프 찍을 수 있도록 수정
- [x] 디테일페이지에서 카카오지도로 주소 넘길 때' 상세 주소로 넘길 수 있도록 로직수정
- [x] 캘린더 매 월 1일과 전월 31일 요일 달라짐 현상 수정
- [x] 캘린더 페이지 상단 달력 고정(리스트만 스크롤되도록 수정)



## 예정사항
수정사항은 거의 처리했는데, 캘린더 날짜선택 후 주단위로 변경 시, 날짜기준을 선택 전 날짜를 기준으로 변경되어서 이 부분 수정해보고있습니다. 
![스크린샷 2023-10-23 오전 10 36 18](https://github.com/Butlers-Team/ticat-client/assets/104641096/bd49cb2f-5b8f-4f4d-b5f9-dcf797246e4f)
![image](https://github.com/Butlers-Team/ticat-client/assets/104641096/53ae27dc-758a-46e9-af3c-004ae4ef8ad7)
![image](https://github.com/Butlers-Team/ticat-client/assets/104641096/c4e544e8-b225-48d0-8744-75131d82c41f)

