### PR TITLE
fix: 회원정보 이름 변경 시 빈칸 허용 버그 및 축제 리스트 탭 네브 오른쪽 화살표 버그 수정

### DIFF
--- a/src/components/festival/CategoryTabNav.tsx
+++ b/src/components/festival/CategoryTabNav.tsx
@@ -47,7 +47,7 @@ const CategoryTabNav = () => {
     if (scrollRef.current) {
       setMaxScrollLeft(scrollRef.current.scrollWidth - scrollRef.current.clientWidth);
     }
-  }, [categoriesTab]); // 탭 카테고리가 변경될 때마다 maxScrollLeft 업데이트
+  }, [categoriesTab, scrollPosition]); // 탭 카테고리가 변경될 때마다 maxScrollLeft 업데이트
 
   /** 2023/08/29 - 메인에서 카테고리 아이콘 클릭 시 tabNav 스크롤 위치 조정 - by sineTlsl */
   useEffect(() => {

--- a/src/pages/ProfileUpdatePage.tsx
+++ b/src/pages/ProfileUpdatePage.tsx
@@ -12,6 +12,9 @@ import { useMemberStore } from '@store/useMemberStore';
 import { CheckCategory } from '@utils/categories';
 import { validateNickname } from '@utils/validateNickname';
 
+// hook
+import useCustomToast from '@hooks/useCustomToast';
+
 // components
 import TopHistoryBackNav from '@components/TopHistoryBackNav';
 import Button from '@components/Button';
@@ -22,6 +25,7 @@ import ProfileInfoNameUpdate from '@components/profile/ProfileInfoNameUpdate';
 /**  2023/08/07 - 프로필 수정 페이지 - by sineTlsl */
 const ProfileUpdatePage = () => {
   const { member, setMember } = useMemberStore();
+  const toast = useCustomToast();
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -43,6 +47,8 @@ const ProfileUpdatePage = () => {
   const interestMutation = useMutation(patchInterest, {
     onSuccess: () => {
       queryClient.invalidateQueries(['userInterest']);
+
+      navigate('/myinfo');
     },
     onError: err => {
       console.log(err);
@@ -83,11 +89,11 @@ const ProfileUpdatePage = () => {
     // 닉네임 유효성 검사
     const errorMessage = validateNickname(memberName);
     if (memberName.length === 0) {
-      alert('닉네임을 입력해주세요.');
+      toast({ title: '닉네임을 입력해주세요 :(', status: 'error' });
       return;
     }
     if (errorMessage) {
-      alert(errorMessage);
+      toast({ title: errorMessage, status: 'error' });
       return; // 에러가 있다면 이후 코드 실행 중지
     }
 

--- a/src/pages/ProfileUpdatePage.tsx
+++ b/src/pages/ProfileUpdatePage.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { MyInfoType } from 'types/api/myinfo';
 import { getInterest, patchMyInfo, patchInterest } from '@api/myinfo';
+import { MyInfoType } from 'types/api/myinfo';
+
+// stores
 import { useMemberStore } from '@store/useMemberStore';
 
 // utils
@@ -51,10 +53,13 @@ const ProfileUpdatePage = () => {
   const profileUpdatemutation = useMutation(patchMyInfo, {
     onSuccess: () => {
       queryClient.invalidateQueries(['userInfo']);
-      // setMember({
-      //   ...member,
-      //   displayName: memberName,
-      // });
+
+      if (member) {
+        setMember({
+          ...member,
+          displayName: memberName,
+        });
+      }
       navigate('/myinfo');
     },
     onError: err => {

--- a/src/pages/ProfileUpdatePage.tsx
+++ b/src/pages/ProfileUpdatePage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { MyInfoType } from 'types/api/myinfo';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { MyInfoType } from 'types/api/myinfo';
 import { getInterest, patchMyInfo, patchInterest } from '@api/myinfo';
+import { useMemberStore } from '@store/useMemberStore';
 
 // utils
 import { CheckCategory } from '@utils/categories';
@@ -18,6 +19,7 @@ import ProfileInfoNameUpdate from '@components/profile/ProfileInfoNameUpdate';
 
 /**  2023/08/07 - 프로필 수정 페이지 - by sineTlsl */
 const ProfileUpdatePage = () => {
+  const { member, setMember } = useMemberStore();
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
@@ -49,6 +51,10 @@ const ProfileUpdatePage = () => {
   const profileUpdatemutation = useMutation(patchMyInfo, {
     onSuccess: () => {
       queryClient.invalidateQueries(['userInfo']);
+      // setMember({
+      //   ...member,
+      //   displayName: memberName,
+      // });
       navigate('/myinfo');
     },
     onError: err => {
@@ -71,6 +77,10 @@ const ProfileUpdatePage = () => {
   const handleProfileUpdate = () => {
     // 닉네임 유효성 검사
     const errorMessage = validateNickname(memberName);
+    if (memberName.length === 0) {
+      alert('닉네임을 입력해주세요.');
+      return;
+    }
     if (errorMessage) {
       alert(errorMessage);
       return; // 에러가 있다면 이후 코드 실행 중지


### PR DESCRIPTION
### Branch
`fe-feat/fixes/#130` -> `dev`

### 변경사항
- 회원정보 이름 변경 시 빈 문자열일 경우에는 메시지 출력
- 회원정보 수정 시 merber 스토어에 저장
- 회원정보 시 발생하는 에러들 alert -> toast로 변경
- 축제 리스트 카테고리 탭 네브바 오른쪽 화살표가 사라지는 버그 수정
